### PR TITLE
Add hint on using the opam-provided utop

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ To use utop in emacs, add the following line to your ~/.emacs file:
 
 Then you can run utop by executing the command `utop` in emacs.
 
+If you installed utop through opam, customize `utop-command` to
+`opam config exec "utop -emacs"`.
+
 Integration with the tuareg/typerex mode
 ----------------------------------------
 


### PR DESCRIPTION
Add hint for using utop as installed by opam (without reloading anything on opam switches), using opam config exec.
