### PR TITLE
Close *Completions* buffer after evaluation

### DIFF
--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -628,9 +628,11 @@ it is started."
      ;; End of completion
      ((string= command "completion-stop")
       (utop-set-state 'edit)
-      (with-current-buffer utop-complete-buffer
-        (with-output-to-temp-buffer "*Completions*"
-          (display-completion-list (nreverse utop-completion))))
+      (if (> (length utop-completion) 1)
+          (with-current-buffer utop-complete-buffer
+            (with-output-to-temp-buffer "*Completions*"
+              (display-completion-list (nreverse utop-completion))))
+        (minibuffer-hide-completions))
       (setq utop-completion nil)))))
 
 (defun utop-process-output (process output)
@@ -669,7 +671,6 @@ automatically inserted by utop.
 
 If ADD-TO-HISTORY is t then the input will be added to history."
   (interactive)
-  (minibuffer-hide-completions)
   (with-current-buffer utop-buffer-name
     (when (eq utop-state 'edit)
       ;; Clear saved pending position


### PR DESCRIPTION
This is a quick fix for #84. There might be a better place in the
code for the fix but this certainly does the trick.
