### PR TITLE
Company backend only complete on utop buffers

### DIFF
--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -1221,7 +1221,8 @@ Special keys for utop:
   (pcase command
     ('interactive (company-begin-backend 'utop-company-backend))
     ('sorted t)
-    ('prefix (company-grab-symbol))
+    ('prefix (and (derived-mode-p 'utop-mode)
+                  (or (company-grab-symbol-cons "\\." 1) 'stop)))
     ('candidates
      (progn
        `(:async


### PR DESCRIPTION
Change the company backend to only work on utop buffers, otherwise it does not passes control to the next backend 