### PR TITLE
Clflags.include_dirs is expected to hold unexpanded directories

### DIFF
--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -1195,7 +1195,7 @@ let autoload = ref true
 
 let args = Arg.align [
   "-absname", Arg.Set Location.absname, " Show absolute filenames in error message";
-  "-I", Arg.String (fun dir ->  Clflags.include_dirs := Misc.expand_directory Config.standard_library dir :: !Clflags.include_dirs), "<dir> Add <dir> to the list of include directories";
+  "-I", Arg.String (fun dir ->  Clflags.include_dirs := dir :: !Clflags.include_dirs), "<dir> Add <dir> to the list of include directories";
   "-init", Arg.String (fun s -> Clflags.init_file := Some s), "<file> Load <file> instead of default init file";
   "-labels", Arg.Clear Clflags.classic, " Use commuting label mode";
   "-no-app-funct", Arg.Clear Clflags.applicative_functors, " Deactivate applicative functors";


### PR DESCRIPTION
`Toploop.set_paths` will do the expansion as needed. Even if right now, the expansion is idempotent, it's better not to do the expansion, because https://github.com/ocaml/ocaml/pull/1569 changes Toploop.set_paths to expand +compiler-libs into +ocamlcommon +ocamlbytecomp etc for compatibility, and the early expansion in utop breaks that.