### PR TITLE
Deprecate OCaml 4.02 version support, add 4.07

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ env:
   global:
   - PACKAGE=utop
   matrix:
-  - OCAML_VERSION=4.02
   - OCAML_VERSION=4.03
   - OCAML_VERSION=4.04
   - OCAML_VERSION=4.05
   - OCAML_VERSION=4.06
+  - OCAML_VERSION=4.07
 os:
   - linux
   - osx


### PR DESCRIPTION
Deprecation due to https://github.com/ocaml-community/utop/pull/246
New version support because of the release.