### PR TITLE
unicode support improvements: wider glyph, combined glyph

### DIFF
--- a/src/lib/uTop.ml
+++ b/src/lib/uTop.ml
@@ -441,7 +441,7 @@ let make_prompt ui profile count size key_sequence (recording, macro_count, macr
               txta;
               Array.make
                 (size.cols - Array.length txta - Array.length txtb)
-                (UChar.of_int 0x2500, { none with foreground = Some (color lcyan blue); bold = Some bold });
+                (Zed_char.unsafe_of_uChar (UChar.of_int 0x2500), { none with foreground = Some (color lcyan blue); bold = Some bold });
               txtb;
             ]
         ) second_line
@@ -464,12 +464,12 @@ let () =
   Hashtbl.add Toploop.directive_table "utop_prompt_simple"
     (Toploop.Directive_none
        (fun () ->
-         prompt := S.map (Printf.ksprintf LTerm_text.of_string "utop [%d]: ") count));
+         prompt := S.map (Printf.ksprintf LTerm_text.of_utf8 "utop [%d]: ") count));
 
   Hashtbl.add Toploop.directive_table "utop_prompt_dummy"
     (Toploop.Directive_none
        (fun () ->
-         prompt := S.const (LTerm_text.of_string "# ")));
+         prompt := S.const (LTerm_text.of_utf8 "# ")));
 
   Hashtbl.add Toploop.directive_table "utop_prompt_fancy_light"
     (Toploop.Directive_none

--- a/src/lib/uTop_lexer.mll
+++ b/src/lib/uTop_lexer.mll
@@ -203,7 +203,7 @@ and cm_string idx= parse
       {
         let uChar= Zed_utf8.unsafe_extract uchar 0 in
         if Zed_char.is_combining_mark uChar then
-          (Error, idx)
+          cm_string idx lexbuf
         else
           let idx2, terminated= string (idx + 1) true lexbuf in
           (String (1, terminated), idx2)


### PR DESCRIPTION
note, this pr depends on another pr in the lambda-term project ocaml-community/lambda-term#71

* UTop_lexer: support combined glyph
* follow the api changes of zed_char and zed_string