### PR TITLE
Fix typo: mode -> modes

### DIFF
--- a/src/top/dune
+++ b/src/top/dune
@@ -2,7 +2,7 @@
  (names utop)
  (libraries utop)
  (flags :standard -safe-string)
- (mode byte)
+ (modes byte)
  (link_flags -linkall))
 
 (rule


### PR DESCRIPTION
Fix the typo introduced in 7e8567682dc4e8126d4f6c6bd4f4e9673a87de6e.