### PR TITLE
Remove camlp4 remnants

### DIFF
--- a/src/lib/uTop.mli
+++ b/src/lib/uTop.mli
@@ -101,34 +101,6 @@ val set_margin_function : (LTerm_geom.size -> int option) -> unit
       ]}
   *)
 
-(** Syntax. *)
-type syntax =
-  | Normal
-      (** No camlp4. *)
-  | Camlp4o
-      (** Camlp4, original syntax. *)
-  | Camlp4r
-      (** Camlp4, revised syntax. *)
-
-val syntax : syntax signal
-  (** The syntax in use. If it is {!Camlp4o} or {!Camlp4r} quotations
-      are recognized. It is modified when you type [#camlp4o] or
-      [#camlp4r]. At the beginning it is {!Normal}. *)
-
-val get_syntax : unit -> syntax
-  (** Returns the current value of {!syntax}. *)
-
-val set_syntax : syntax -> unit
-  (** Changes the syntax used in utop. If the syntax is the same as
-      the current one, it does nothing. Otherwise it loads camlp4 and
-      setup several configuration variables.
-
-      Notes:
-      - the syntax can only be changed once. Once you set it to
-        {!Camlp4o} or {!Camlp4r} you cannot change it again.
-      - Typing [#camlp4o] is the same as calling [set_syntax Camlp4o].
-      - Typing [#camlp4r] is the same as calling [set_syntax Camlp4r]. *)
-
 val phrase_terminator : string signal
   (** The phrase terminator. It is ";;" by default and ";" when you
       use revised syntax. *)

--- a/src/lib/uTop_complete.mli
+++ b/src/lib/uTop_complete.mli
@@ -9,8 +9,8 @@
 
 (** OCaml completion. *)
 
-val complete : syntax : UTop.syntax -> phrase_terminator : string -> input : string -> int * (string * string) list
-  (** [complete ~syntax ~phrase_terminator ~input] returns the start
+val complete : phrase_terminator : string -> input : string -> int * (string * string) list
+  (** [complete ~phrase_terminator ~input] returns the start
       of the completed word in [input] and the list of possible
       completions with their suffixes. *)
 

--- a/src/lib/uTop_lexer.mli
+++ b/src/lib/uTop_lexer.mli
@@ -7,6 +7,6 @@
  * This file is a part of utop.
  *)
 
-val lex_string : UTop.syntax -> string -> (UTop_token.t * UTop_token.location) list
-  (** [lex_string syntax str] returns all the tokens contained in
+val lex_string : string -> (UTop_token.t * UTop_token.location) list
+  (** [lex_string str] returns all the tokens contained in
       [str]. *)

--- a/src/lib/uTop_lexer.mll
+++ b/src/lib/uTop_lexer.mll
@@ -75,36 +75,28 @@ let float_literal =
 let symbolchar =
   ['!' '$' '%' '&' '*' '+' '-' '.' '/' ':' '<' '=' '>' '?' '@' '^' '|' '~']
 
-rule tokens syntax context idx acc = parse
+rule tokens context idx acc = parse
   | eof
       { (idx, None, List.rev acc) }
   | ('\n' | blank)+
       { let loc = lexeme_loc idx lexbuf in
-        tokens syntax context loc.idx2 ((Blanks, loc) :: acc) lexbuf }
+        tokens context loc.idx2 ((Blanks, loc) :: acc) lexbuf }
   | lident
       { let src = lexeme lexbuf in
         let loc = lexeme_loc idx lexbuf in
         let tok =
-          match syntax, src with
-            | (UTop.Normal | UTop.Camlp4o), ("true" | "false") ->
+          match src with
+            | ("true" | "false") ->
                 Constant src
             | _ ->
                 Lident src
         in
-        tokens syntax context loc.idx2 ((tok, loc) :: acc) lexbuf }
+        tokens context loc.idx2 ((tok, loc) :: acc) lexbuf }
   | uident
       { let src = lexeme lexbuf in
         let loc = lexeme_loc idx lexbuf in
-        let tok =
-          match syntax, src with
-            | UTop.Camlp4r, "True" ->
-                Constant "true"
-            | UTop.Camlp4r, "False" ->
-                Constant "false"
-            | _ ->
-                Uident src
-        in
-        tokens syntax context loc.idx2 ((tok, loc) :: acc) lexbuf }
+        let tok = Uident src in
+        tokens context loc.idx2 ((tok, loc) :: acc) lexbuf }
   | int_literal "l"
   | int_literal "L"
   | int_literal "n"
@@ -112,18 +104,18 @@ rule tokens syntax context idx acc = parse
   | float_literal
       { let loc = lexeme_loc idx lexbuf in
         let tok = Constant (lexeme lexbuf) in
-        tokens syntax context loc.idx2 ((tok, loc) :: acc) lexbuf }
+        tokens context loc.idx2 ((tok, loc) :: acc) lexbuf }
   | '"'
       { let ofs = lexeme_start lexbuf in
         let item, idx2= cm_string (idx + 1) lexbuf in
         let loc = mkloc idx idx2 ofs (lexeme_end lexbuf) in
-        tokens syntax context idx2 ((item, loc) :: acc) lexbuf }
+        tokens context idx2 ((item, loc) :: acc) lexbuf }
   | '{' (lowercase* as tag) '|'
       { let ofs = lexeme_start lexbuf in
         let delim_len = String.length tag + 2 in
         let idx2, terminated = quoted_string (idx + delim_len) tag false lexbuf in
         let loc = mkloc idx idx2 ofs (lexeme_end lexbuf) in
-        tokens syntax context idx2 ((String (delim_len, terminated), loc) :: acc) lexbuf }
+        tokens context idx2 ((String (delim_len, terminated), loc) :: acc) lexbuf }
   | "'" [^'\'' '\\'] "'"
   | "'\\" ['\\' '"' 'n' 't' 'b' 'r' ' ' '\'' 'x' '0'-'9'] eof
   | "'\\" ['\\' '"' 'n' 't' 'b' 'r' ' ' '\''] "'"
@@ -131,37 +123,30 @@ rule tokens syntax context idx acc = parse
   | "'\\" (['0'-'9'] ['0'-'9'] ['0'-'9'] | 'x' hexa_char hexa_char) eof
   | "'\\" (['0'-'9'] ['0'-'9'] ['0'-'9'] | 'x' hexa_char hexa_char) "'"
       { let loc = lexeme_loc idx lexbuf in
-        tokens syntax context loc.idx2 ((Char, loc) :: acc) lexbuf }
+        tokens context loc.idx2 ((Char, loc) :: acc) lexbuf }
   | "'\\" uchar
       { let loc = mkloc idx (idx + 3) (lexeme_start lexbuf) (lexeme_end lexbuf) in
-        tokens syntax context loc.idx2 ((Error, loc) :: acc) lexbuf }
+        tokens context loc.idx2 ((Error, loc) :: acc) lexbuf }
   | "(*)"
       { let loc = lexeme_loc idx lexbuf in
-        tokens syntax context loc.idx2 ((Comment (Comment_reg, true), loc) :: acc) lexbuf }
+        tokens context loc.idx2 ((Comment (Comment_reg, true), loc) :: acc) lexbuf }
   | "(**)"
       { let loc = lexeme_loc idx lexbuf in
-        tokens syntax context loc.idx2 ((Comment (Comment_doc, true), loc) :: acc) lexbuf }
+        tokens context loc.idx2 ((Comment (Comment_doc, true), loc) :: acc) lexbuf }
   | "(**"
       { let ofs = lexeme_start lexbuf in
         let idx2, terminated = comment (idx + 3) 0 false lexbuf in
         let loc = mkloc idx idx2 ofs (lexeme_end lexbuf) in
-        tokens syntax context idx2 ((Comment (Comment_doc, terminated), loc) :: acc) lexbuf }
+        tokens context idx2 ((Comment (Comment_doc, terminated), loc) :: acc) lexbuf }
   | "(*"
       { let ofs = lexeme_start lexbuf in
         let idx2, terminated = comment (idx + 2) 0 false lexbuf in
         let loc = mkloc idx idx2 ofs (lexeme_end lexbuf) in
-        tokens syntax context idx2 ((Comment (Comment_reg, terminated), loc) :: acc) lexbuf }
+        tokens context idx2 ((Comment (Comment_reg, terminated), loc) :: acc) lexbuf }
   | ""
-      { if syntax = UTop.Normal then
-          symbol syntax context idx acc lexbuf
-        else
-          match context with
-            | Toplevel ->
-                camlp4_toplevel syntax context idx acc lexbuf
-            | Antiquot ->
-                camlp4_antiquot syntax context idx acc lexbuf }
+      { symbol context idx acc lexbuf }
 
-and symbol syntax context idx acc = parse
+and symbol context idx acc = parse
   | "(" | ")"
   | "[" | "]"
   | "{" | "}"
@@ -172,7 +157,7 @@ and symbol syntax context idx acc = parse
   | symbolchar+
       { let loc = lexeme_loc idx lexbuf in
         let tok = Symbol (lexeme lexbuf) in
-        tokens syntax context loc.idx2 ((tok, loc) :: acc) lexbuf }
+        tokens context loc.idx2 ((tok, loc) :: acc) lexbuf }
   | uchar as uchar
       { let uChar= Zed_utf8.unsafe_extract uchar 0 in
         if Zed_char.is_combining_mark uChar then
@@ -186,10 +171,10 @@ and symbol syntax context idx acc = parse
             | _-> tok
           in
           let loc= { loc with ofs2= lexeme_end lexbuf } in
-          tokens syntax context loc.idx2 ((tok, loc) :: tl) lexbuf
+          tokens context loc.idx2 ((tok, loc) :: tl) lexbuf
         else
           let loc = mkloc idx (idx + 1) (lexeme_start lexbuf) (lexeme_end lexbuf) in
-          tokens syntax context loc.idx2 ((Error, loc) :: acc) lexbuf
+          tokens context loc.idx2 ((Error, loc) :: acc) lexbuf
       }
 
 and cm_string idx= parse
@@ -210,23 +195,6 @@ and cm_string idx= parse
       }
   | eof
       { (String (1, false), idx) }
-
-and camlp4_toplevel syntax context idx acc = parse
-  | '<' (':' ident)? ('@' lident)? '<'
-      { let ofs = lexeme_start lexbuf in
-        let idx2, items, terminated = quotation syntax 0 idx (idx + lexeme_size lexbuf) (lexeme_start lexbuf) false lexbuf in
-        let ofs2 = lexeme_end lexbuf in
-        tokens syntax context idx2
-          ((Quotation (items, terminated), mkloc idx idx2 ofs ofs2) :: acc)
-          lexbuf }
-  | ""
-      { symbol syntax context idx acc lexbuf }
-
-and camlp4_antiquot syntax context idx acc = parse
-  | '$'
-      { (idx + 1, Some (lexeme_loc idx lexbuf), List.rev acc) }
-  | ""
-      { camlp4_toplevel syntax context idx acc lexbuf }
 
 and comment idx depth combining= parse
   | "(*"
@@ -302,15 +270,15 @@ and quoted_string idx tag combining= parse
               quoted_string (idx + 1) tag true lexbuf
         }
 
-and quotation syntax depth idx1 idx2 ofs1 combining= parse
+and quotation depth idx1 idx2 ofs1 combining= parse
   | '<' (':' ident)? ('@' lident)? '<'
-      { quotation syntax (depth + 1) idx1 (idx2 + lexeme_size lexbuf) ofs1 false lexbuf }
+      { quotation (depth + 1) idx1 (idx2 + lexeme_size lexbuf) ofs1 false lexbuf }
   | ">>"
       { if depth = 0 then
           let loc = mkloc idx1 (idx2 + 2) ofs1 (lexeme_end lexbuf) in
           (idx2 + 2, [(Quot_data, loc)], true)
         else
-          quotation syntax (depth - 1) idx1 (idx2 + 2) ofs1 false lexbuf }
+          quotation (depth - 1) idx1 (idx2 + 2) ofs1 false lexbuf }
   | '$'
       { let quot_data_loc =
           if idx1 = idx2 then
@@ -320,7 +288,7 @@ and quotation syntax depth idx1 idx2 ofs1 combining= parse
         in
         let opening_loc = lexeme_loc idx2 lexbuf in
         let idx, name = quotation_name (idx2 + 1) lexbuf in
-        let idx, closing_loc, items = tokens syntax Antiquot idx [] lexbuf in
+        let idx, closing_loc, items = tokens Antiquot idx [] lexbuf in
         let anti = {
           a_opening = opening_loc;
           a_closing = closing_loc;
@@ -329,7 +297,7 @@ and quotation syntax depth idx1 idx2 ofs1 combining= parse
         } in
         let ofs = lexeme_end lexbuf in
         let loc = mkloc opening_loc.idx1 idx opening_loc.ofs2 ofs in
-        let idx, quot_items, terminated = quotation syntax depth idx idx ofs false lexbuf in
+        let idx, quot_items, terminated = quotation depth idx idx ofs false lexbuf in
         let quot_items = (Quot_anti anti, loc) :: quot_items in
         match quot_data_loc with
           | Some loc ->
@@ -340,14 +308,14 @@ and quotation syntax depth idx1 idx2 ofs1 combining= parse
       { let uChar= Zed_utf8.unsafe_extract uchar 0 in
         if not combining then
           if Zed_char.is_combining_mark uChar then
-            quotation syntax depth idx1 (idx2 + 1) ofs1 false lexbuf
+            quotation depth idx1 (idx2 + 1) ofs1 false lexbuf
           else
-            quotation syntax depth idx1 (idx2 + 1) ofs1 true lexbuf
+            quotation depth idx1 (idx2 + 1) ofs1 true lexbuf
         else
           if Zed_char.is_combining_mark uChar then
-            quotation syntax depth idx1 idx2 ofs1 true lexbuf
+            quotation depth idx1 idx2 ofs1 true lexbuf
           else
-            quotation syntax depth idx1 (idx2 + 1) ofs1 true lexbuf
+            quotation depth idx1 (idx2 + 1) ofs1 true lexbuf
       }
   | eof
       { if idx1 = idx2 then
@@ -366,7 +334,7 @@ and quotation_name idx = parse
       { (idx, None) }
 
 {
-  let lex_string syntax str =
-    let _, _, items = tokens syntax Toplevel 0 [] (Lexing.from_string str) in
+  let lex_string str =
+    let _, _, items = tokens Toplevel 0 [] (Lexing.from_string str) in
     items
 }

--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -224,7 +224,7 @@ class read_phrase ~term = object(self)
         styled.(i) <- (ch, LTerm_style.merge token_style style)
       done
     in
-    UTop_styles.stylise stylise (UTop_lexer.lex_string (UTop.get_syntax ()) (Zed_string.to_utf8 (LTerm_text.to_string styled)));
+    UTop_styles.stylise stylise (UTop_lexer.lex_string (Zed_string.to_utf8 (LTerm_text.to_string styled)));
 
     if not last then
       (* Parenthesis matching. *)
@@ -249,7 +249,6 @@ class read_phrase ~term = object(self)
   method! completion =
     let pos, words =
       UTop_complete.complete
-        ~syntax:(UTop.get_syntax ())
         ~phrase_terminator:(UTop.get_phrase_terminator ())
         ~input:(Zed_string.to_utf8 (Zed_rope.to_string self#input_prev))
     in
@@ -306,7 +305,7 @@ let render_out_phrase term string =
         styled.(i) <- (ch, LTerm_style.merge token_style style)
       done
     in
-    UTop_styles.stylise stylise (UTop_lexer.lex_string (UTop.get_syntax ()) string);
+    UTop_styles.stylise stylise (UTop_lexer.lex_string string);
     LTerm.fprints term styled
   end
 
@@ -1088,7 +1087,6 @@ module Emacs(M : sig end) = struct
         let input = read_data () in
         let _, words =
           UTop_complete.complete
-            ~syntax:(UTop.get_syntax ())
             ~phrase_terminator:(UTop.get_phrase_terminator ())
             ~input
         in
@@ -1100,7 +1098,6 @@ module Emacs(M : sig end) = struct
           let input = read_data () in
           let start, words =
             UTop_complete.complete
-              ~syntax:(UTop.get_syntax ())
               ~phrase_terminator:(UTop.get_phrase_terminator ())
               ~input
           in

--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -211,11 +211,6 @@ to add the newline character if it is not accepted).")
    "List of packages to load when visiting OCaml buffer.
 Useful as file variable."))
 
-(make-variable-buffer-local
- (defvar utop-ocaml-preprocessor nil
-   "Name of preprocesor. Currently supported camlp4o, camlp4r.
-Useful as file variable."))
-
 (defvar utop-next-phrase-beginning 'utop-compat-next-phrase-beginning
   "The function used to find the beginning of the next phrase.")
 


### PR DESCRIPTION
Despite camlp4 and camlp5 mentioned as removed in 2.0.0 version https://github.com/ocaml-community/utop/blob/master/CHANGES.md#200-2016-05-26, camlp4 syntax still handled in the code. Removing the clutter then. See also https://github.com/ocaml-community/utop/issues/289 issue.