### PR TITLE
Remove now-broken elisp that depends on utop-ocaml-preprocessor

### DIFF
--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -1023,10 +1023,6 @@ defaults to 0."
 
 (defun utop-hack-local-variables ()
   "Perform actions defined by local variables"
-  (when utop-ocaml-preprocessor
-    (with-current-buffer (utop))
-    (utop-eval-string (format "#%s" utop-ocaml-preprocessor))
-    (message (format "uTop: %s OCaml preprocessor loaded" utop-ocaml-preprocessor)))
   (utop-query-load-package-list))
 
 ;; +-----------------------------------------------------------------+


### PR DESCRIPTION
A recent commit deleted the variable utop-ocaml-preprocessor in utop.el, but there are still some references to that variable, causing the error
`Symbol’s value as variable is void: utop-ocaml-preprocessor`

This pull request deletes the remaining references to utop-ocaml-preprocessor.