### PR TITLE
#infoof directive

### DIFF
--- a/src/lib/config/ocp_index_off.ml
+++ b/src/lib/config/ocp_index_off.ml
@@ -3,6 +3,4 @@ let complete _input _names_of_module _global_names= function
 
 let add_directive _directive_table _render_out_phrase _print_error= ()
 
-let load _packages= ()
-
-let load_deeply _package= ()
+let init_ocp_index ()= -1

--- a/src/lib/config/ocp_index_off.ml
+++ b/src/lib/config/ocp_index_off.ml
@@ -1,0 +1,8 @@
+let complete _input _names_of_module _global_names= function
+  | _-> None
+
+let add_directive _directive_table _render_out_phrase _print_error= ()
+
+let load _packages= ()
+
+let load_deeply _package= ()

--- a/src/lib/config/ocp_index_on.ml
+++ b/src/lib/config/ocp_index_on.ml
@@ -37,13 +37,14 @@ let complete input names_of_module global_names= function
 #if OCAML_VERSION >= (4, 04, 0)
 let lookup_type longident env = Env.lookup_type longident env
 #else
-let lookup_type id env= let path, _= Env.lookup_type in path
+let lookup_type id env= let path, _= Env.lookup_type id env in path
 #endif
 
 let req_query= ref stdout
 let rep_query= ref stdin
 
 let infoof render_out_phrase print_error sid =
+  let sid= String.trim sid in
   let id  = Longident.parse sid in
   let env = !Toploop.toplevel_env in
   let from_type_desc = function

--- a/src/lib/config/ocp_index_on.ml
+++ b/src/lib/config/ocp_index_on.ml
@@ -1,0 +1,106 @@
+open LTerm_read_line
+open UTop_token
+
+module String_set = Set.Make(String)
+module String_map = Map.Make(String)
+
+let cmd_input_line cmd =
+  try
+    let ic = Unix.open_process_in (cmd ^ " 2>/dev/null") in
+    let r = input_line ic in
+    let r =
+      let len = String.length r in
+      if len>0 && r.[len - 1] = '\r' then String.sub r 0 (len-1) else r
+    in
+    match Unix.close_process_in ic with
+    | Unix.WEXITED 0 -> r
+    | _ -> failwith "cmd_input_line"
+  with
+  | End_of_file | Unix.Unix_error _ | Sys_error _ -> failwith "cmd_input_line"
+
+let index=
+  let ocaml_lib= try (cmd_input_line) "ocamlc -where" with _-> "" in
+  let opam_lib= try (cmd_input_line) "opam config var lib" with _-> "" in
+  LibIndex.load @@ LibIndex.Misc.unique_subdirs [ocaml_lib; opam_lib]
+
+let complete input names_of_module global_names= function
+  | [(Symbol "#", _); (Lident "infoof", _); (String (tlen, false), loc)] ->
+    let prefix = String.sub input (loc.ofs1 + tlen) (String.length input - loc.ofs1 - tlen) in
+    begin match Longident.parse prefix with
+    | Longident.Ldot (lident, last_prefix) ->
+      let set = names_of_module lident in
+      let compls = lookup last_prefix (String_set.elements set) in
+      let start = loc.idx1 + 1 + (String.length prefix - String.length last_prefix) in
+      Some (start, List.map (fun w -> (w, "")) compls)
+    | _ ->
+      let set = global_names () in
+      let compls = lookup prefix (String_set.elements set) in
+      Some (loc.idx1 + 1, List.map (fun w -> (w, "")) compls)
+    end
+  | _-> None
+
+#if OCAML_VERSION >= (4, 04, 0)
+let lookup_type longident env = Env.lookup_type longident env
+#else
+let lookup_type id env= let path, _= Env.lookup_type in path
+#endif
+
+let infoof render_out_phrase print_error sid =
+  let id  = Longident.parse sid in
+  let env = !Toploop.toplevel_env in
+  let from_type_desc = function
+    | Types.Tconstr (path, _, _) ->
+      let typ_decl = Env.find_type path env in
+      path, typ_decl
+    | _ -> assert false
+  in
+  let name=
+    try
+      let path = lookup_type id env in
+      Some (Path.name path)
+    with Not_found ->
+    try
+      let (path, _val_descr) = Env.lookup_value id env in
+      Some (Path.name path)
+    with Not_found ->
+    try
+      let lbl_desc = Env.lookup_label id env in
+      let (path, _ty_decl) = from_type_desc lbl_desc.Types.lbl_res.Types.desc in
+      Some (Path.name path)
+    with Not_found ->
+    try
+      let path = Env.lookup_module id env ~load:true in
+      Some (Path.name path)
+    with Not_found ->
+    try
+      let (path, _mty_decl) = Env.lookup_modtype id env in
+      Some (Path.name path)
+    with Not_found ->
+    try
+      let cstr_desc = Env.lookup_constructor id env in
+      match cstr_desc.Types.cstr_tag with
+      | _ ->
+        let (path, _ty_decl) = from_type_desc cstr_desc.Types.cstr_res.Types.desc in
+        Some (Path.name path)
+    with Not_found ->
+      None
+  in
+  let open Lwt in
+  match name with
+  | None ->
+    (try
+      let info= LibIndex.Print.info ~color:false (LibIndex.get index sid) in
+      Lwt_main.run (Lazy.force LTerm.stdout >>= fun term -> render_out_phrase term info)
+    with Not_found->
+      Lwt_main.run (Lazy.force LTerm.stdout >>= fun term -> print_error term "Unknown info\n"))
+  | Some name ->
+    try
+      let info= LibIndex.Print.info ~color:false (LibIndex.get index name) in
+      Lwt_main.run (Lazy.force LTerm.stdout >>= fun term -> render_out_phrase term info)
+    with Not_found->
+      Lwt_main.run (Lazy.force LTerm.stdout >>= fun term -> print_error term "Unknown info\n")
+
+let add_directive directive_table render_out_phrase print_error=
+  Hashtbl.add directive_table "infoof"
+    (Toploop.Directive_string (infoof render_out_phrase print_error))
+

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -1,12 +1,15 @@
 (library
- (name uTop)
- (public_name utop)
- (wrapped false)
- (flags :standard -safe-string)
- (modes byte)
- (libraries compiler-libs.toplevel findlib.top lambda-term threads)
- (preprocess
-  (action
-   (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file}))))
+  (name uTop)
+  (public_name utop)
+  (wrapped false)
+  (flags :standard -safe-string)
+  (modes byte)
+  (libraries compiler-libs.toplevel findlib.top lambda-term threads
+    (select ocp_index_hook.ml from
+      (ocp-index.lib -> config/ocp_index_on.ml)
+      (!ocp-index.lib -> config/ocp_index_off.ml)))
+  (preprocess
+    (action
+      (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file}))))
 
 (ocamllex uTop_lexer)

--- a/src/lib/uTop_complete.ml
+++ b/src/lib/uTop_complete.ml
@@ -1002,77 +1002,82 @@ let complete ~phrase_terminator ~input =
         let result = lookup name list in
         (loc.idx2 - Zed_utf8.length name, List.map (function dir -> (dir, "")) result)
 
-    (* Generic completion on directives. *)
-    | [(Symbol "#", _); ((Lident dir | Uident dir), _); (Blanks, { idx2 = stop })] ->
-        (stop,
-         match try Some (Hashtbl.find Toploop.directive_table dir) with Not_found -> None with
-           | Some (Toploop.Directive_none _) -> [(phrase_terminator, "")]
-           | Some (Toploop.Directive_string _) -> [(" \"", "")]
-           | Some (Toploop.Directive_bool _) -> [(true_name, phrase_terminator); (false_name, phrase_terminator)]
-           | Some (Toploop.Directive_int _) -> []
-           | Some (Toploop.Directive_ident _) -> List.map (fun w -> (w, "")) (String_set.elements (global_names ()))
-           | None -> [])
-    | (Symbol "#", _) :: ((Lident dir | Uident dir), _) :: tokens -> begin
-        match try Some (Hashtbl.find Toploop.directive_table dir) with Not_found -> None with
-          | Some (Toploop.Directive_none _) ->
-              (0, [])
-          | Some (Toploop.Directive_string _) ->
-              (0, [])
-          | Some (Toploop.Directive_bool _) -> begin
-              match tokens with
-                | [(Lident id, { idx1 = start })] ->
-                    (start, lookup_assoc id [(true_name, phrase_terminator); (false_name, phrase_terminator)])
-                | _ ->
-                    (0, [])
-            end
-          | Some (Toploop.Directive_int _) ->
-              (0, [])
-          | Some (Toploop.Directive_ident _) -> begin
-              match parse_longident (List.rev tokens) with
-                | Some (Value, None, start, id) ->
-                    (start, List.map (fun w -> (w, "")) (lookup id (String_set.elements (global_names ()))))
-                | Some (Value, Some longident, start, id) ->
-                    (start, List.map (fun w -> (w, "")) (lookup id (String_set.elements (names_of_module longident))))
-                | _ ->
-                    (0, [])
-            end
-          | None ->
-              (0, [])
-      end
+    | _-> match Ocp_index_hook.complete input names_of_module global_names tokens with
+      | Some r-> r
+      | None->
+        match tokens with
 
-    (* Completion on identifiers. *)
-    | _ ->
-        match find_context tokens tokens with
-          | None ->
-              (0, [])
-          | Some [] ->
-              (0, List.map (fun w -> (w, "")) (String_set.elements (String_set.union !UTop.keywords (global_names ()))))
-          | Some tokens ->
-              match parse_method tokens with
-                | Some (longident, meths, start, meth) ->
-                    (start, List.map (fun w -> (w, "")) (lookup meth (methods_of_object longident meths)))
-                | None ->
-                    match parse_label tokens with
-                      | Some (Fun, longident, meths, Optional, start, label) ->
-                          (start, List.map (fun (w, kind) -> (w, ":")) (lookup_assoc label (List.filter (function (w, Optional) -> true | (w, Required) -> false) (labels_of_function longident meths))))
-                      | Some (Fun, longident, meths, Required, start, label) ->
-                          (start, List.map (fun (w, kind) -> (w, ":")) (lookup_assoc label (labels_of_function longident meths)))
-                      | Some (New, longident, meths, Optional, start, label) ->
-                          (start, List.map (fun (w, kind) -> (w, ":")) (lookup_assoc label (List.filter (function (w, Optional) -> true | (w, Required) -> false) (labels_of_newclass longident))))
-                      | Some (New, longident, meths, Required, start, label) ->
-                          (start, List.map (fun (w, kind) -> (w, ":")) (lookup_assoc label (labels_of_newclass longident)))
-                      | None ->
-                          match parse_longident tokens with
-                            | None ->
-                                (0, [])
-                            | Some (Value, None, start, id) ->
-                                (start, List.map (fun w -> (w, "")) (lookup id (String_set.elements (String_set.union !UTop.keywords (global_names ())))))
-                            | Some (Value, Some longident, start, id) ->
-                                (start, List.map (fun w -> (w, "")) (lookup id (String_set.elements (names_of_module longident))))
-                            | Some (Field, None, start, id) ->
-                                (start, List.map (fun w -> (w, "")) (lookup id (String_set.elements (global_fields ()))))
-                            | Some (Field, Some longident, start, id) ->
-                                (start, List.map (fun w -> (w, "")) (lookup id (String_set.elements (fields_of_module longident))))
+        (* Generic completion on directives. *)
+        | [(Symbol "#", _); ((Lident dir | Uident dir), _); (Blanks, { idx2 = stop })] ->
+            (stop,
+            match try Some (Hashtbl.find Toploop.directive_table dir) with Not_found -> None with
+              | Some (Toploop.Directive_none _) -> [(phrase_terminator, "")]
+              | Some (Toploop.Directive_string _) -> [(" \"", "")]
+              | Some (Toploop.Directive_bool _) -> [(true_name, phrase_terminator); (false_name, phrase_terminator)]
+              | Some (Toploop.Directive_int _) -> []
+              | Some (Toploop.Directive_ident _) -> List.map (fun w -> (w, "")) (String_set.elements (global_names ()))
+              | None -> [])
+        | (Symbol "#", _) :: ((Lident dir | Uident dir), _) :: tokens -> begin
+            match try Some (Hashtbl.find Toploop.directive_table dir) with Not_found -> None with
+              | Some (Toploop.Directive_none _) ->
+                  (0, [])
+              | Some (Toploop.Directive_string _) ->
+                  (0, [])
+              | Some (Toploop.Directive_bool _) -> begin
+                  match tokens with
+                    | [(Lident id, { idx1 = start })] ->
+                        (start, lookup_assoc id [(true_name, phrase_terminator); (false_name, phrase_terminator)])
+                    | _ ->
+                        (0, [])
+                end
+              | Some (Toploop.Directive_int _) ->
+                  (0, [])
+              | Some (Toploop.Directive_ident _) -> begin
+                  match parse_longident (List.rev tokens) with
+                    | Some (Value, None, start, id) ->
+                        (start, List.map (fun w -> (w, "")) (lookup id (String_set.elements (global_names ()))))
+                    | Some (Value, Some longident, start, id) ->
+                        (start, List.map (fun w -> (w, "")) (lookup id (String_set.elements (names_of_module longident))))
+                    | _ ->
+                        (0, [])
+                end
+              | None ->
+                  (0, [])
+          end
+
+        (* Completion on identifiers. *)
+        | _ ->
+            match find_context tokens tokens with
+              | None ->
+                  (0, [])
+              | Some [] ->
+                  (0, List.map (fun w -> (w, "")) (String_set.elements (String_set.union !UTop.keywords (global_names ()))))
+              | Some tokens ->
+                  match parse_method tokens with
+                    | Some (longident, meths, start, meth) ->
+                        (start, List.map (fun w -> (w, "")) (lookup meth (methods_of_object longident meths)))
+                    | None ->
+                        match parse_label tokens with
+                          | Some (Fun, longident, meths, Optional, start, label) ->
+                              (start, List.map (fun (w, kind) -> (w, ":")) (lookup_assoc label (List.filter (function (w, Optional) -> true | (w, Required) -> false) (labels_of_function longident meths))))
+                          | Some (Fun, longident, meths, Required, start, label) ->
+                              (start, List.map (fun (w, kind) -> (w, ":")) (lookup_assoc label (labels_of_function longident meths)))
+                          | Some (New, longident, meths, Optional, start, label) ->
+                              (start, List.map (fun (w, kind) -> (w, ":")) (lookup_assoc label (List.filter (function (w, Optional) -> true | (w, Required) -> false) (labels_of_newclass longident))))
+                          | Some (New, longident, meths, Required, start, label) ->
+                              (start, List.map (fun (w, kind) -> (w, ":")) (lookup_assoc label (labels_of_newclass longident)))
+                          | None ->
+                              match parse_longident tokens with
+                                | None ->
+                                    (0, [])
+                                | Some (Value, None, start, id) ->
+                                    (start, List.map (fun w -> (w, "")) (lookup id (String_set.elements (String_set.union !UTop.keywords (global_names ())))))
+                                | Some (Value, Some longident, start, id) ->
+                                    (start, List.map (fun w -> (w, "")) (lookup id (String_set.elements (names_of_module longident))))
+                                | Some (Field, None, start, id) ->
+                                    (start, List.map (fun w -> (w, "")) (lookup id (String_set.elements (global_fields ()))))
+                                | Some (Field, Some longident, start, id) ->
+                                    (start, List.map (fun w -> (w, "")) (lookup id (String_set.elements (fields_of_module longident))))
 
 let complete ~phrase_terminator ~input =
   try

--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -1487,7 +1487,7 @@ let main_aux ~initial_env =
 
 let main_internal ~initial_env =
   try
-    main_aux ~initial_env;
+    main_aux ~initial_env
   with exn ->
     (match exn with
        | Unix.Unix_error (error, func, "") ->
@@ -1503,6 +1503,7 @@ let main_internal ~initial_env =
 let main () =
   let child_ocp_index= Ocp_index_hook.init_ocp_index () in
   let children= [child_ocp_index] in
+  let children= List.filter (fun child-> child > 0) children in
   Lwt_main.at_exit (fun ()->
     List.iter (fun child-> Unix.kill child Sys.sigterm) children; Lwt.return ());
   main_internal ~initial_env:None

--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -1247,6 +1247,8 @@ let () =
   Hashtbl.add Toploop.directive_table "typeof"
     (Toploop.Directive_string typeof)
 
+let ()= Ocp_index_hook.add_directive Toploop.directive_table render_out_phrase print_error
+
 (* +-----------------------------------------------------------------+
    | Entry point                                                     |
    +-----------------------------------------------------------------+ *)

--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -1487,7 +1487,7 @@ let main_aux ~initial_env =
 
 let main_internal ~initial_env =
   try
-    main_aux ~initial_env
+    main_aux ~initial_env;
   with exn ->
     (match exn with
        | Unix.Unix_error (error, func, "") ->
@@ -1500,7 +1500,12 @@ let main_internal ~initial_env =
     flush stderr;
     exit 2
 
-let main () = main_internal ~initial_env:None
+let main () =
+  let child_ocp_index= Ocp_index_hook.init_ocp_index () in
+  let children= [child_ocp_index] in
+  Lwt_main.at_exit (fun ()->
+    List.iter (fun child-> Unix.kill child Sys.sigterm) children; Lwt.return ());
+  main_internal ~initial_env:None
 
 type value = V : string * _ -> value
 

--- a/utop.opam
+++ b/utop.opam
@@ -18,6 +18,9 @@ depends: [
   "cppo" {build & >= "1.1.2"}
   "dune" {build}
 ]
+depopts: [
+  "ocp-index"
+]
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
This PR add a depopt, ocp-index to utop. If utop is built when ocp-index is installed, a new directive, `#infoof`, is provided.

This directive works similarly to `#typeof`. The symbol resolving and completion mechanism is based on the current Env of the Toploop. That is, if we type `open String;;` in utop, #infoof "concat" will still find out the very infomation of `String.concat`

<details><summary>Click to expand</summary>

![image](https://user-images.githubusercontent.com/357626/61932736-b5c4e800-afb6-11e9-808e-89ddac93065e.png)
</details>