### PR TITLE
Fixes for 4.09

### DIFF
--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -625,13 +625,23 @@ let bind_expressions name phrase =
 let execute_phrase =
   let new_cmis = ref []in
 
-  let default_load = !Env.Persistent_signature.load in
+  let default_load =
+#if OCAML_VERSION >= (4, 09, 0)
+    !Persistent_env.Persistent_signature.load
+#else
+    !Env.Persistent_signature.load
+#endif
+  in
   let load ~unit_name =
     let res = default_load ~unit_name in
     (match res with None -> () | Some x -> new_cmis := x.cmi :: !new_cmis);
     res
   in
+#if OCAML_VERSION >= (4, 09, 0)
+  Persistent_env.Persistent_signature.load := load;
+#else
   Env.Persistent_signature.load := load;
+#endif
 
   let rec collect_printers path signature acc =
     List.fold_left (fun acc item ->


### PR DESCRIPTION
This PR fixes the compilation with OCaml 4.09:

  - The use of `Obj.truncated` for overriding `Sys.argv` is replaced by a call to `caml_sys_modify_argv`
  - Iteration on the typed tree is implemented with `Tast_iterator` rather than `TypedtreeIter`.
  - Loading persistent signature is done with `Persistent_env.Persistent_signature`

Closes #298 