### PR TITLE
Add OCaml 4.09 and 4.10.0+beta1 to the CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ script: bash -ex .travis-opam.sh
 env:
   global:
   - PACKAGE=utop
+  - FORK_USER=kit-ty-kate
+  - FORK_BRANCH=410
   matrix:
   - OCAML_VERSION=4.03
   - OCAML_VERSION=4.04
@@ -12,6 +14,8 @@ env:
   - OCAML_VERSION=4.06
   - OCAML_VERSION=4.07
   - OCAML_VERSION=4.08
+  - OCAML_VERSION=4.09
+  - OPAM_SWITCH=4.10.0+beta1 OCAML_BETA=enable
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ script: bash -ex .travis-opam.sh
 env:
   global:
   - PACKAGE=utop
-  - FORK_USER=kit-ty-kate
-  - FORK_BRANCH=410
   matrix:
   - OCAML_VERSION=4.03
   - OCAML_VERSION=4.04
@@ -15,7 +13,7 @@ env:
   - OCAML_VERSION=4.07
   - OCAML_VERSION=4.08
   - OCAML_VERSION=4.09
-  - OPAM_SWITCH=4.10.0+beta1 OCAML_BETA=enable
+  - OPAM_SWITCH=4.10.0+rc2 OCAML_BETA=enable
 os:
   - linux
   - osx


### PR DESCRIPTION
OCaml 4.09 and 4.10 are not tested by your CI. This PR fixes that.

This PR is for now a draft as it relies on https://github.com/ocaml/ocaml-ci-scripts/pull/320 to be able to test 4.10.0beta1 but should be mergeable as soon as it gets merged.