### PR TITLE
Backport the #use_output directive from OCaml 4.11

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ next
 ----
 
 - Load init file from ~/.config/utop/init.ml as per XDG conventions (@copy, #144)
+- Backport the #use_output directive (@diml, #...)
 
 2.4.3 (2019-12-31)
 ------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@ next
 ----
 
 - Load init file from ~/.config/utop/init.ml as per XDG conventions (@copy, #144)
-- Backport the #use_output directive (@diml, #...)
+- Backport the #use_output directive (@diml, #313)
 
 2.4.3 (2019-12-31)
 ------------------

--- a/src/lib/uTop.ml
+++ b/src/lib/uTop.ml
@@ -748,9 +748,16 @@ let () =
    +-----------------------------------------------------------------+ *)
 
 
+let try_finally ~always work=
+#if OCAML_VERSION >= (4, 08, 0)
+    Misc.try_finally ~always work
+#else
+    Misc.try_finally work always
+#endif
+
 let use_output command =
   let fn = Filename.temp_file "ocaml" "_toploop.ml" in
-  Misc.try_finally ~always:(fun () ->
+  try_finally ~always:(fun () ->
     try Sys.remove fn with Sys_error _ -> ())
     (fun () ->
        match

--- a/src/lib/uTop.ml
+++ b/src/lib/uTop.ml
@@ -744,6 +744,34 @@ let () =
        (fun str -> require (split_words str)))
 
 (* +-----------------------------------------------------------------+
+   | Backports                                                       |
+   +-----------------------------------------------------------------+ *)
+
+
+let use_output command =
+  let fn = Filename.temp_file "ocaml" "_toploop.ml" in
+  Misc.try_finally ~always:(fun () ->
+    try Sys.remove fn with Sys_error _ -> ())
+    (fun () ->
+       match
+         Printf.ksprintf Sys.command "%s > %s"
+           command
+           (Filename.quote fn)
+       with
+       | 0 ->
+         ignore (Toploop.use_file Format.std_formatter fn : bool)
+       | n ->
+         Format.printf "Command exited with code %d.@." n)
+
+let () =
+  let name = "use_output" in
+  if not (Hashtbl.mem Toploop.directive_table name) then
+    Hashtbl.add
+      Toploop.directive_table
+      name
+      (Toploop.Directive_string use_output)
+
+(* +-----------------------------------------------------------------+
    | Initialization                                                  |
    +-----------------------------------------------------------------+ *)
 


### PR DESCRIPTION
I added a `#use_output` directive in the trunk of OCaml (https://github.com/ocaml/ocaml/pull/9283). I propose to backport this feature in utop so that it is available to users of OCaml < 4.11.