### PR TITLE
Vi edit mode

### DIFF
--- a/src/lib/uTop.ml
+++ b/src/lib/uTop.ml
@@ -467,6 +467,8 @@ let default_prompt =
 
 let prompt = ref default_prompt
 
+let edit_mode= ref LTerm_editor.Default
+
 let () =
   Hashtbl.add Toploop.directive_table "utop_prompt_simple"
     (Toploop.Directive_none
@@ -488,7 +490,17 @@ let () =
     (Toploop.Directive_none
        (fun () ->
          set_profile Dark;
-         prompt := default_prompt))
+         prompt := default_prompt));
+
+  Hashtbl.add Toploop.directive_table "edit_mode_default"
+    (Toploop.Directive_none
+       (fun () ->
+         edit_mode:= LTerm_editor.Default));
+
+  Hashtbl.add Toploop.directive_table "edit_mode_vi"
+    (Toploop.Directive_none
+       (fun () ->
+         edit_mode:= LTerm_editor.Vi))
 
 (* +-----------------------------------------------------------------+
    | Help                                                            |

--- a/src/lib/uTop.mli
+++ b/src/lib/uTop.mli
@@ -234,6 +234,11 @@ val time : float ref
 val prompt : LTerm_text.t React.signal ref
   (** The prompt. *)
 
+(** {6 Edit mode configuration} *)
+
+val edit_mode : LTerm_editor.mode ref
+  (** The edit mode. *)
+
 (** {6 Hooks} *)
 
 val new_command_hooks : (unit -> unit) LTerm_dlist.t

--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -712,7 +712,12 @@ let execute_phrase = Toploop.execute_phrase
 
 let rec read_phrase term =
   Lwt.catch
-    (fun () -> (new read_phrase ~term)#run)
+    (fun () ->
+       let read_line= new read_phrase ~term in
+       (match !UTop.edit_mode with
+       | LTerm_editor.Default-> ()
+       | LTerm_editor.Vi as mode-> read_line#set_editor_mode mode);
+       read_line#run)
     (function
     | Sys.Break ->
       LTerm.fprintl term "Interrupted." >>= fun () ->

--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -175,7 +175,7 @@ class read_phrase ~term = object(self)
     in
     super#send_action action
 
-  method! exec = function
+  method! exec ?(keys=[]) = function
     | action :: actions when S.value self#mode = LTerm_read_line.Edition &&
                              is_accept action  -> begin
         Zed_macro.add self#macro action;
@@ -205,11 +205,11 @@ class read_phrase ~term = object(self)
               UTop_history.add_warnings UTop.stashable_session_history warnings;
               UTop_history.add_error UTop.stashable_session_history msg;
           end;
-          return result
+          return (LTerm_read_line.Result result)
         with UTop.Need_more ->
           (* Input not finished, continue. *)
           self#insert (UChar.of_char '\n');
-          self#exec actions
+          self#exec ~keys actions
       end
     | actions ->
       super_term#exec actions


### PR DESCRIPTION
Add two new directive: edit_mode_default and edit_mode_vi to trigger vi edit mode. resolve #136
This PR depends on ocaml-community/lambda-term/pull/85