### PR TITLE
2.5.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,16 @@
-next
-----
+2.5.0 (2020-04-26)
+------------------
 
-- Load init file from ~/.config/utop/init.ml as per XDG conventions (@copy, #144)
-- Backport the #use_output directive (@diml, #313)
+### Additions
+
+* add `#edit_mode_vi` and `#edit_mode_default` mode to set the editing mode(@kandu)
+* Backport the `#use_output` directive (@diml, #313)
+
+### General
+
+* Load init file from ~/.config/utop/init.ml as per XDG conventions (@copy, #144)
+* Add OCaml 4.09 and 4.10 to the CI matrix (@kit-ty-kate, #310)
+* Add documentation for dune utop usage in emacs (@samarthkishor, #307)
 
 2.4.3 (2019-12-31)
 ------------------

--- a/man/utop.1
+++ b/man/utop.1
@@ -36,7 +36,7 @@ as you type. The highlighted word in the completion bar is the
 selected word. You can navigate using the keys Alt+Left and Alt+Right
 and you can complete using the currently selected word by pressing
 Alt+Tab (you can configure these bindings in the file
-.I ~/.lambda-term-inputrc
+.I ~/.config/lambda-term-inputrc
 , see
 .BR lambda-term-inputrc (5)
 for details).
@@ -108,7 +108,7 @@ The alternative initialization file of the toplevel.
 The configuration file for utop. See
 .BR utoprc (5).
 .RE
-.I ~/.lambda-term-inputrc
+.I ~/.config/lambda-term-inputrc
 .RS
 The file containing key bindings. See
 .BR lambda-term-inputrc (5).

--- a/utop.opam
+++ b/utop.opam
@@ -10,7 +10,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}
-  "lambda-term" {>= "2.0" & < "3.0"}
+  "lambda-term" {>= "3.0.0" & < "4.0"}
   "lwt"
   "lwt_react"
   "camomile"


### PR DESCRIPTION
2.5.0 (2020-04-26)
------------------

### Additions

* add `#edit_mode_vi` and `#edit_mode_default` mode to set the editing mode(@kandu)
* Backport the `#use_output` directive (@diml, #313)

### General

* Load init file from ~/.config/utop/init.ml as per XDG conventions (@copy, #144)
* Add OCaml 4.09 and 4.10 to the CI matrix (@kit-ty-kate, #310)
* Add documentation for dune utop usage in emacs (@samarthkishor, #307)