### PR TITLE
Clarification for company mode completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ copy&paste this to your `~/.emacs`:
 (autoload 'utop "utop" "Toplevel for OCaml" t)
 ```
 
+Utop in emacs also supports TAB-completion. If your version of emacs includes `company` completion will appear at the code point. Otherwise completion will appear in a seperate buffer. If your emacs supports company but you aren't seeing the completion drop-down please try adding a global hook for company mode to your `~/.emacs`:
+
+```elisp`
+(add-hook 'after-init-hook 'global-company-mode)
+```
+
 ### Usage
 
 Then you can execute utop inside emacs with: `M-x utop`.


### PR DESCRIPTION
New to emacs so not sure if this is was implied or anything. Was using the spacemacs flavour of emacs and wasn't getting any code completion in utop despite seeing it work properly with the merlin-mode. Was able to fix this by adding this to my `~/.emacs`

```elisp`
(add-hook 'after-init-hook 'global-company-mode)
```
Figured might as well try posting in-case it helps anyone else in a similar position.

But as mentioned for some reason this worked out of the box for merlin mode - my (very much a) guess is due to:

```
(require 'company)
```