### PR TITLE
release 2.6.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,9 @@
-next
+2.6.0 (2020-05-30)
 ------------------
 
-* compatible with OCaml 4.11
-* switch to the exposed parser
+* compatible with OCaml 4.11 (@kit-ty-kate, #322)
+* switch to the new parser exposed since 4.11
+* Vi edit mode: register support
 
 2.5.0 (2020-04-26)
 ------------------

--- a/utop.opam
+++ b/utop.opam
@@ -10,7 +10,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}
-  "lambda-term" {>= "3.0.0" & < "4.0"}
+  "lambda-term" {>= "3.1.0" & < "4.0"}
   "lwt"
   "lwt_react"
   "camomile"


### PR DESCRIPTION
2.6.0 (2020-05-30)
------------------

* compatible with OCaml 4.11 (@kit-ty-kate, #322)
* switch to the new parser exposed since 4.11
* vi_edit_mode: register support