### PR TITLE
Make sure we're not at $HOME before sourcing local .ocamlinit

### DIFF
--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -1479,7 +1479,7 @@ let common_init ~initial_env =
            None
          )
      | None ->
-         if Sys.file_exists ".ocamlinit" && Sys.getcwd () <> Sys.getenv "HOME" then
+         if Sys.file_exists ".ocamlinit" && Sys.getcwd () <> LTerm_resources.home then
            Some ".ocamlinit"
          else
            let xdg_fn = LTerm_resources.xdgbd_file ~loc:LTerm_resources.Config "utop/init.ml" in

--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -1479,7 +1479,7 @@ let common_init ~initial_env =
            None
          )
      | None ->
-         if Sys.file_exists ".ocamlinit" then
+         if Sys.file_exists ".ocamlinit" && Sys.getcwd () <> Sys.getenv "HOME" then
            Some ".ocamlinit"
          else
            let xdg_fn = LTerm_resources.xdgbd_file ~loc:LTerm_resources.Config "utop/init.ml" in


### PR DESCRIPTION
fixes: #333, #325

this `if...else` clause can be bypassed entirely if we don't automatically source `.ocamlinit` in the current project directory and instead pass it as `-init` explicitly.

Not sure what's the default expected ocaml toplevel behaviour though.