### PR TITLE
utop.el: Fix utop-tuareg-next-phrase for newer tuareg.el

### DIFF
--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -5,7 +5,7 @@
 ;; URL: https://github.com/diml/utop
 ;; Licence: BSD3
 ;; Version: 1.11
-;; Package-Requires: ((emacs "24"))
+;; Package-Requires: ((emacs "24") (tuareg "2.2.0"))
 ;; Keywords: ocaml languages
 
 ;; This file is a part of utop.
@@ -20,6 +20,7 @@
 (require 'easymenu)
 (require 'pcase)
 (require 'tabulated-list)
+(require 'tuareg)
 
 ;; +-----------------------------------------------------------------+
 ;; | License                                                         |
@@ -269,12 +270,18 @@ modes you need to set these variables:
 
 (defun utop-tuareg-next-phrase ()
   "Move to the next phrase after point."
-  (let* ((pos (tuareg--after-double-colon))
+  (let* ((pos (save-excursion
+                (when (looking-at-p "[;[:blank:]]*$")
+                  (skip-chars-backward ";[:blank:]")
+                  (when (> (point) 1)
+                    (- (point) 1)))))
          (pos (if pos pos (point)))
          (phrase (tuareg-discover-phrase pos)))
     (when phrase
       (goto-char (caddr phrase))
-      (tuareg--skip-double-colon)
+      (tuareg-skip-blank-and-comments)
+      (when (looking-at ";;[ \t\n]*")
+        (goto-char (match-end 0)))
       (tuareg-skip-blank-and-comments))))
 
 (defun utop-compat-next-phrase-beginning ()


### PR DESCRIPTION
`tuareg--after-double-colon` no longer exists in the latest rev of
Tuareg, so inline the old definition, which was removed in
commit 91ba1d6143558092a3920e9b5c49755c0c86caed of Tuareg.

`tuareg--skip-double-colon` was renamed to `tuareg--skip-double-semicolon`. Also inline this, to avoid depending on a private function.