### PR TITLE
Utop correctly restarts when (not utop-edit-command)

### DIFF
--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -1074,8 +1074,8 @@ defaults to 0."
   "Return the arguments of the utop command to run."
   ;; Read the command to run
   (when utop-edit-command
-    (setq utop-command (read-shell-command "utop command line: " utop-command))
-    (utop-arguments)))
+    (setq utop-command (read-shell-command "utop command line: " utop-command)))
+  (utop-arguments))
 
 (defun utop-start (arguments)
   "Start utop given ARGUMENTS."


### PR DESCRIPTION
## Problem

If `utop-edit-command` is nil, then `utop-query-arguments` returns nil.
This breaks `utop-restart` which relies upon it returning the right arguments.

## Solution

`utop-query-arguments` always returns `(utop-arguments)` whether it sets the utop-command or not.