### PR TITLE
Fix color highlight for errors.

### DIFF
--- a/src/lib/uTop.mli
+++ b/src/lib/uTop.mli
@@ -254,6 +254,12 @@ type location = int * int
     (** Type of a string-location. It is composed of a start and stop
         offsets (in bytes). *)
 
+type lines = {
+  start: int;
+  stop:  int;
+}
+    (** Type for a range of lines in a buffer from start to stop. *)
+
 (** Result of a function processing a programx. *)
 type 'a result =
   | Value of 'a
@@ -310,12 +316,12 @@ val get_message : (Format.formatter -> 'a -> unit) -> 'a -> string
   (** [get_message printer x] applies [printer] on [x] and
       returns everything it prints as a string. *)
 
-val get_ocaml_error_message : exn -> location * string
+val get_ocaml_error_message : exn -> location * string * (lines option)
   (** [get_ocaml_error_message exn] returns the location and error
       message for the exception [exn] which must be an exception from
       the compiler. *)
 
-val check_phrase : Parsetree.toplevel_phrase -> (location list * string) option
+val check_phrase : Parsetree.toplevel_phrase -> (location list * string * lines option list) option
   (** [check_phrase phrase] checks that [phrase] can be executed
       without typing or compilation errors. It returns [None] if
       [phrase] is OK and an error message otherwise.


### PR DESCRIPTION
The output from the compiler changed and now mentions the line number
(non only the charters, which actually becomes columns). This patch
introduces the idea of a range of lines spanned by an error and
correctly marks the faulty region.

I think a better solution would be to introduce a "point" record of
the form {line:int;column:int}. However, such a change would
reverberate through all the source code and so it is much more
invasive. I can prepare such a patch if desired, after this one, which
fixes the regression.

This was tested with OCaml 4.11.2 and 4.12.

Fixes #349