### PR TITLE
Support OCaml 5, again

### DIFF
--- a/src/lib/uTop.mli
+++ b/src/lib/uTop.mli
@@ -342,7 +342,7 @@ val split_words : string -> string list
  (** {6 compiler-libs reexports and helpers} *)
 
 val otherlibs : string list
-  (** The list of packages in otherlibs that will be loaded by [load_otherlibs]. *)
+  (** The list of packages in otherlibs that will be loaded by {!val:load_otherlibs}. *)
 
 val load_otherlibs : unit -> unit
   (** [load_otherlibs] explicitly loads packages from OCaml otherlibs (e.g., str and unix). *)

--- a/src/lib/uTop.mli
+++ b/src/lib/uTop.mli
@@ -339,14 +339,23 @@ val discard_formatters : Format.formatter list -> (unit -> 'a) -> 'a
 
 val split_words : string -> string list
 
- (** {6 compiler-libs reexports} *)
+ (** {6 compiler-libs reexports and helpers} *)
+
+val otherlibs : string list
+  (** The list of packages in otherlibs that will be loaded by [load_otherlibs]. *)
+
+val load_otherlibs : unit -> unit
+  (** [load_otherlibs] explicitly loads packages from OCaml otherlibs (e.g., str and unix). *)
 
 val get_load_path : unit -> string list
-val set_load_path : string list -> unit
+val set_load_path : ?otherlibs:bool -> string list -> unit
   (** [get_load_path] and [set_load_path] manage the include directories.
 
       The internal variable contains the list of directories added by findlib-required packages
-      and [#directory] directives. *)
+      and [#directory] directives.
+
+      @params otherlibs Whether to additionally load OCaml otherlibs (e.g., str and unix).
+      The default is [not !Clflags.no_std_include]. *)
 
 (**/**)
 

--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -1453,7 +1453,7 @@ let args = Arg.align [
   "-no-app-funct", Arg.Clear Clflags.applicative_functors, " Deactivate applicative functors";
   "-noassert", Arg.Set Clflags.noassert, " Do not compile assertion checks";
   "-nolabels", Arg.Set Clflags.classic, " Ignore non-optional labels in types";
-  "-nostdlib", Arg.Set Clflags.no_std_include, " Do not add default directory to the list of include directories";
+  "-nostdlib", Arg.Set Clflags.no_std_include, " Do not add default directory to the list of include directories and prevent utop from loading otherlibs (e.g., str and unix)";
   "-ppx", Arg.String (fun ppx -> Clflags.all_ppx := ppx :: !Clflags.all_ppx), "<command> Pipe abstract syntax trees through preprocessor <command>";
   "-principal", Arg.Set Clflags.principal, " Check principality of type inference";
 #if OCAML_VERSION < (5, 0, 0)

--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -1596,6 +1596,7 @@ let protocol_version = 1
 
 let main_aux ~initial_env =
   Arg.parse args file_argument usage;
+  if not !Clflags.no_std_include then UTop.load_otherlibs ();
 #if OCAML_VERSION >= (5, 0, 0)
   Topcommon.load_topdirs_signature ();
 #endif


### PR DESCRIPTION
This PR makes utop compile again with OCaml 5. The main change is to explicitly load packages from OCaml otherlibs, following the spirit of https://github.com/ocaml/ocaml/pull/11198.

**API changes:** I introduced `UTop.otherlibs` and `UTop.load_otherlibs` and an optional argument to `UTop.set_load_path` to control whether that function should load packages from OCaml otherlibs automatically.

**Caveats:** I did not test the new code with older versions of OCaml. It is possible that the explicit list of packages (`UTop.otherlibs`) depends on the version of the OCaml compiler. I don't have the energy to check older versions of OCaml and please feel free to update this PR.