### PR TITLE
Support new Load_path.init API

### DIFF
--- a/src/lib/uTop.ml
+++ b/src/lib/uTop.ml
@@ -854,11 +854,16 @@ let () =
    +-----------------------------------------------------------------+ *)
 
 #if OCAML_VERSION >= (4, 08, 0)
-let get_load_path ()= Load_path.get_paths ()
-let set_load_path path= Load_path.init path
+let get_load_path () = Load_path.get_paths ()
+#if OCAML_VERSION >= (5, 0, 0)
+let set_load_path path =
+  Load_path.init path ~auto_include:Load_path.no_auto_include
 #else
-let get_load_path ()= !Config.load_path
-let set_load_path path= Config.load_path := path
+let set_load_path path = Load_path.init path
+#endif
+#else
+let get_load_path () = !Config.load_path
+let set_load_path path = Config.load_path := path
 #endif
 
 (* +-----------------------------------------------------------------+

--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -1371,7 +1371,11 @@ let emacs_mode = ref false
 let preload = ref []
 
 let prepare () =
+#if OCAML_VERSION >= (5, 0, 0)
+  Toploop.set_paths ~auto_include:Load_path.no_auto_include ();
+#else
   Toploop.set_paths ();
+#endif
   try
     let ok =
       List.for_all


### PR DESCRIPTION
Smaller version of https://github.com/ocaml-community/utop/pull/376 without the `Utop.load_otherlibs` part. Additional OCaml PR incoming to aid it as well.