### PR TITLE
Update README.md with correct filepath.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ UTop.set_show_box false
 ### Key bindings
 
 Key bindings in the terminal can be changed by writing a
-`~/.lambda-term-inputrc` file. For example:
+`~/.config/lambda-term-inputrc` file. For example:
 
     [read-line]
     C-left: complete-bar-prev


### PR DESCRIPTION
The readme states

> 'Key bindings in the terminal can be changed by writing a ~/.lambda-term-inputrc file. For example:'

However, after writing this file and then exiting utop after it's next restart generates the below warning:

```Warning: it is recommended to move `/home/owen/.lambda-term-inputrc` to `$XDG_CONFIG_HOME`, see:
http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html```

