### PR TITLE
Compatibility with zed 3.2.0

### DIFF
--- a/src/lib/dune
+++ b/src/lib/dune
@@ -4,7 +4,7 @@
  (wrapped false)
  (flags :standard -safe-string)
  (modes byte)
- (libraries compiler-libs.toplevel findlib.top lambda-term threads)
+ (libraries compiler-libs.toplevel findlib.top lambda-term threads zed)
  (preprocess
   (action
    (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file}))))

--- a/src/lib/uTop.ml
+++ b/src/lib/uTop.ml
@@ -9,7 +9,6 @@
 
 [@@@warning "-27"]
 
-open CamomileLibraryDefault.Camomile
 open Lwt_react
 open LTerm_text
 open LTerm_geom
@@ -477,7 +476,7 @@ let make_prompt ui profile count size key_sequence (recording, macro_count, macr
               txta;
               Array.make
                 (size.cols - Array.length txta - Array.length txtb)
-                (Zed_char.unsafe_of_uChar (UChar.of_int 0x2500), { none with foreground = Some (color lcyan blue); bold = Some bold });
+                (Zed_char.of_utf8 "\u{2500}", { none with foreground = Some (color lcyan blue); bold = Some bold });
               txtb;
             ]
         ) second_line

--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -9,7 +9,6 @@
 
 [@@@warning "-7-9-27-32-33"]
 
-open CamomileLibraryDefault.Camomile
 open Lwt_react
 open LTerm_dlist
 open LTerm_text
@@ -256,7 +255,7 @@ class read_phrase ~term = object(self)
           return (LTerm_read_line.Result result)
         with UTop.Need_more ->
           (* Input not finished, continue. *)
-          self#insert (UChar.of_char '\n');
+          self#insert (Uchar.of_char '\n');
           self#exec ~keys actions
       end
     | actions ->
@@ -328,7 +327,7 @@ let fix_string str =
     let buf = Buffer.create (len + 128) in
     if ofs > 0 then Buffer.add_substring buf str 0 ofs;
     let rec loop ofs =
-      Zed_utf8.add buf (UChar.of_char str.[ofs]);
+      Zed_utf8.add buf (Uchar.of_char str.[ofs]);
       let ofs1 = ofs + 1 in
       let ofs2, _, _ = Zed_utf8.next_error str ofs1 in
       if ofs1 < ofs2 then

--- a/utop.opam
+++ b/utop.opam
@@ -13,7 +13,7 @@ depends: [
   "lambda-term" {>= "3.1.0" & < "4.0"}
   "lwt"
   "lwt_react"
-  "camomile"
+  "zed" { >= "3.2.0" }
   "react" {>= "1.0.0"}
   "cppo" {build & >= "1.1.2"}
   "dune" {>= "1.0"}


### PR DESCRIPTION
This updates utop to use the uu packages instead of camomile, following ocaml-community/zed#46 and ocaml-community/lambda-term#109.
