### PR TITLE
Doc: only mention dependencies in the opam file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,22 +20,8 @@ The easiest and recommended way of installing utop is via
 
     $ opam install utop
 
-If you want to build it manually, you should install all the
-dependencies listed in the next section.
-
-Dependencies
-------------
-
-* [OCaml](http://caml.inria.fr/ocaml/) (>= 4.03.0)
-* [Dune](http://github.com/ocaml/dune)
-* [findlib](http://projects.camlcity.org/projects/findlib.html) (>= 1.4.0)
-* [cppo](http://mjambon.com/cppo.html) (>= 1.0.1)
-* [react](http://erratique.ch/software/react)
-* [lwt](http://ocsigen.org/lwt/) (>= 2.4.0) built with react support
-* [Camomile](http://github.com/yoriyuki/Camomile) (>= 0.8)
-* [zed](http://github.com/ocaml-community/zed) (>= 3.0)
-* [lambda-term](http://github.com/ocaml-community/lambda-term) (>= 3.0)
-* [mew\_vi](http://github.com/kandu/mew_vi)
+If you want to build it manually, refer to the opam file which lists the
+dependencies.
 
 Installation from sources
 -------------------------


### PR DESCRIPTION
This avoids hard to maintain duplication.
