### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @diml @rgrinberg
+* @rgrinberg


### PR DESCRIPTION
Seems the original @diml user no longer exists and GH flagged this as an error. (the current username was registered in 2021, so I doubt that's the author of utop)

In general I don't think CODEOWNERS makes much sense if you just have 1-2 owners for everything, so it should be reconsidered at some point.  E.g. it'd be better if subsystems like Emacs support had different owners or something like this. 