### PR TITLE
[Fix #358] Fix code completion for module identifiers in utop.el

### DIFF
--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -243,7 +243,7 @@ backend")
 
 (defun utop--supports-company ()
   (and
-   ;; version< only works on version numbers 
+   ;; version< only works on version numbers
    (condition-case nil
        (version<= "1" utop-protocol-version)
      (error t))
@@ -650,9 +650,14 @@ it is started."
       ("completion"
        (catch 'done
          (dolist (prefix utop-completion-prefixes)
-           (when (string-prefix-p prefix argument)
-             (push argument utop-completion)
-             (throw 'done t)))))
+           ;; We need to handle specially prefixes like "List.m" as
+           ;; the responses from utop don't include the module prefix.
+           (let ((prefix (if (string-match-p "\\." prefix)
+                             (cadr (split-string prefix "\\."))
+                           prefix)))
+             (when (string-prefix-p prefix argument)
+              (push argument utop-completion)
+              (throw 'done t))))))
       ;; End of completion
       ("completion-stop"
        (utop-set-state 'edit)


### PR DESCRIPTION
Without those changes you won't get any completion for things like
"List.m". I'm not very familiar with the code, but it seems that the
backend returns the completion candidates without the module prefix
which caused the problem.

I've opted to fix this by handling prefixes with a "." in them specially
and this works fine in the limited testing I conducted locally.