### PR TITLE
Add commands to switch to and from a utop buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,13 +218,14 @@ You can start utop inside Emacs with: `M-x utop`.
 
 `utop.el` also ships with a minor mode that has the following key-bindings:
 
-| key-binding | function          | Description                  |
-|-------------|-------------------|------------------------------|
-| C-c C-s     | utop              | Start a utop buffer          |
-| C-x C-e     | utop-eval-phrase  | Evaluate the current phrase  |
-| C-x C-r     | utop-eval-region  | Evaluate the selected region |
-| C-c C-b     | utop-eval-buffer  | Evaluate the current buffer  |
-| C-c C-k     | utop-kill         | Kill a running utop process  |
+| key-binding | function            | Description                  |
+|-------------|---------------------|------------------------------|
+| C-c C-s     | utop                | Start a utop buffer          |
+| C-x C-e     | utop-eval-phrase    | Evaluate the current phrase  |
+| C-x C-r     | utop-eval-region    | Evaluate the selected region |
+| C-c C-b     | utop-eval-buffer    | Evaluate the current buffer  |
+| C-c C-k     | utop-kill           | Kill a running utop process  |
+| C-c C-z     | utop-switch-to-repl | Switch to utop process       |
 
 You can enable the minor mode using `M-x utop-minor-mode`, or you can
 have it enabled by default with the following configuration:


### PR DESCRIPTION
Those are extremely common in Emacs modes and allow people to
quickly jump to a REPL and back to the last source buffer they
were editing, while using the same keybinding.

I've modeled the implementation here after that of inf-clojure (a similar
mode written by me). I've also implemented a mode menu for
utop-minor-mode, so it's easier for the users to discover its
functionality.