### PR TITLE
Do not display a backtrace when exiting normally

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Unreleased
 
 * Bump the compatibility to 4.08+ (#393 @emillon)
 * Load `@toplevel_printer` annotated printers for functors (#378 @metavinek)
+* Do not display a backtrace when exiting normally (#399 #398 @emillon)
 
 2.10.0 (2022-10-06)
 ------------------

--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -1632,23 +1632,22 @@ let main_aux ~initial_env =
   exit 0
 
 let main_internal ~initial_env =
-  let exit_status = ref 2 in
   try
     main_aux ~initial_env
   with exn ->
     (match exn with
+#if OCAML_VERSION >= (4,12,0)
+       | Compenv.Exit_with_status e -> exit e
+#endif
        | Unix.Unix_error (error, func, "") ->
            Printf.eprintf "%s: %s: %s\n" app_name func (Unix.error_message error)
        | Unix.Unix_error (error, func, arg) ->
          Printf.eprintf "%s: %s(%S): %s\n" app_name func arg (Unix.error_message error)
-#if OCAML_VERSION >= (4,12,0)
-       | Compenv.Exit_with_status e -> exit_status := e
-#endif
        | exn ->
            Printf.eprintf "Fatal error: exception %s\n" (Printexc.to_string exn));
     Printexc.print_backtrace stderr;
     flush stderr;
-    exit !exit_status
+    exit 2
 
 let main () = main_internal ~initial_env:None
 


### PR DESCRIPTION
Exiting normally here refers to the `Exit_with_status` exception. It is in particular triggered by `#quit;;` so we want to exit quietly in that case.

Closes #398
