### PR TITLE
utop.el: always insert phrase terminator at the end-ish of input

### DIFF
--- a/src/lib/uTop.mli
+++ b/src/lib/uTop.mli
@@ -102,8 +102,7 @@ val set_margin_function : (LTerm_geom.size -> int option) -> unit
   *)
 
 val phrase_terminator : string signal
-  (** The phrase terminator. It is ";;" by default and ";" when you
-      use revised syntax. *)
+  (** The phrase terminator, ";;". *)
 
 val get_phrase_terminator : unit -> string
   (** Returns the value of {!phrase_terminator}. *)

--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -838,7 +838,7 @@ If ADD-TO-HISTORY is t then the input will be added to history."
   "Go to the beginning of line or to the end of the prompt."
   (interactive)
   (with-current-buffer utop-buffer-name
-    (if (= (point-at-bol) utop-prompt-min)
+    (if (= (line-beginning-position) utop-prompt-min)
         (goto-char utop-prompt-max)
       (move-beginning-of-line 1))))
 

--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -649,8 +649,8 @@ If ALLOW-INCOMPLETE is non-nil and the phrase is not terminated,
 then a newline character will be inserted and edition will
 continue.
 
-If AUTO-END is non-nill then ALLOW-INCOMPLETE is ignored and a
-phrase terminator (;; or ; if using revised syntax) will be
+If AUTO-END is non-nill then ALLOW-INCOMPLETE is ignored and the
+phrase terminator (;;) will be
 automatically inserted by utop.
 
 If ADD-TO-HISTORY is t then the input will be added to history."

--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -649,7 +649,7 @@ If ALLOW-INCOMPLETE is non-nil and the phrase is not terminated,
 then a newline character will be inserted and edition will
 continue.
 
-If AUTO-END is non-nill then ALLOW-INCOMPLETE is ignored and the
+If AUTO-END is non-nil then ALLOW-INCOMPLETE is ignored and the
 phrase terminator (;;) will be
 automatically inserted by utop.
 

--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -486,14 +486,10 @@ it is started."
 
 (defun utop-insert-phrase-terminator ()
   "Insert the phrase terminator at the end of buffer."
-  ;; Search the longest suffix of the input which is a prefix of the
-  ;; phrase terminator
-  (let* ((end (point-max))
-         (pos (max utop-prompt-max (- end (length utop-phrase-terminator)))))
-    (while (not (string-prefix-p (buffer-substring-no-properties pos end) utop-phrase-terminator))
-      (setq pos (1+ pos)))
-    ;; Insert only the missing part
-    (insert (substring utop-phrase-terminator (- end pos)))))
+  (re-search-forward ";*[ \t\n\r]*\\'")
+  (goto-char (match-beginning 0))
+  (unless (looking-at-p ";;")
+    (insert ";;")))
 
 (defun utop-process-line (line)
   "Process one line from the utop sub-process."


### PR DESCRIPTION
When point is at the letter "n" in

utop[1]> let thi[n]g = 42

and the user presses C-j, it is always because they want to terminate
the expression at the end-ish of the input.

The unpatched behavior did not move point, and inserted two semicolons
in the middle of the expression.