### PR TITLE
use M-down instead of M-tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To use utop, simply run:
 
 utop display a bar after the prompt which is used to show possible
 completions in real-time. You can navigate in it using `M-left` and
-`M-right`, and select one completion using `M-tab`. The `M` denotes
+`M-right`, and select one completion using `M-down`. The `M` denotes
 the meta key, which is `Alt` most of the time.
 
 Customization


### PR DESCRIPTION
Both Alt-TAB and Alt-Down already work in utop. But in many OSes, Alt-Tab is reserved for switching windows. Moreover, once your fingers are on LEFT/RIGHT, I think having to move to TAB is not practical. So I think that it makes more sense to advertise ALT-down in the README file.
