### PR TITLE
Move compat functions to their module

### DIFF
--- a/src/lib/uTop.ml
+++ b/src/lib/uTop.ml
@@ -16,13 +16,6 @@ open LTerm_style
 
 let (>>=) = Lwt.(>>=)
 
-let toploop_get_directive name =
-#if OCAML_VERSION >= (4, 13, 0)
-  Toploop.get_directive name
-#else
-  try Some (Hashtbl.find Toploop.directive_table name) with Not_found -> None
-#endif
-
 module String_set = Set.Make(String)
 
 let version = "%%VERSION%%"
@@ -812,7 +805,7 @@ let use_output command =
 
 let () =
   let name = "use_output" in
-  if toploop_get_directive name = None then
+  if UTop_compat.toploop_get_directive name = None then
     Toploop.add_directive
       name
       (Toploop.Directive_string use_output)
@@ -838,12 +831,7 @@ let () =
    +-----------------------------------------------------------------+ *)
 
 let get_load_path () = Load_path.get_paths ()
-#if OCAML_VERSION >= (5, 0, 0)
-let set_load_path path =
-  Load_path.init path ~auto_include:Load_path.no_auto_include
-#else
-let set_load_path path = Load_path.init path
-#endif
+let set_load_path = UTop_compat.set_load_path
 
 (* +-----------------------------------------------------------------+
    | Deprecated                                                      |

--- a/src/lib/uTop_compat.ml
+++ b/src/lib/uTop_compat.ml
@@ -1,0 +1,132 @@
+let lookup_value =
+#if OCAML_VERSION >= (4, 10, 0)
+  Env.find_value_by_name
+#else
+  Env.lookup_value
+#endif
+
+let get_desc x =
+#if OCAML_VERSION >= (4, 14, 0)
+  Types.get_desc x
+#else
+  x.Types.desc
+#endif
+
+let toploop_get_directive name =
+#if OCAML_VERSION >= (4, 13, 0)
+  Toploop.get_directive name
+#else
+  try Some (Hashtbl.find Toploop.directive_table name) with Not_found -> None
+#endif
+
+let lookup_module name env =
+#if OCAML_VERSION >= (4, 10, 0)
+  let path, md = Env.find_module_by_name name env in
+#else
+  let path = Env.lookup_module name env ~load:true in
+  let md = Env.find_module path env in
+#endif
+  (path, md.md_type)
+
+let lookup_label =
+#if OCAML_VERSION >= (4, 10, 0)
+  Env.find_label_by_name
+#else
+  Env.lookup_label
+#endif
+
+let lookup_modtype =
+#if OCAML_VERSION >= (4, 10, 0)
+  Env.find_modtype_by_name
+#else
+  Env.lookup_modtype
+#endif
+
+let lookup_constructor =
+#if OCAML_VERSION >= (4, 10, 0)
+  Env.find_constructor_by_name
+#else
+  Env.lookup_constructor
+#endif
+
+let lookup_class=
+#if OCAML_VERSION >= (4, 10, 0)
+  Env.find_class_by_name
+#else
+  Env.lookup_class
+#endif
+
+let longident_parse str =
+#if OCAML_VERSION >= (4, 11, 0)
+  let lexbuf = Lexing.from_string str in
+  Parse.longident lexbuf
+#else
+  Longident.parse str
+#endif
+
+let toploop_all_directive_names () =
+#if OCAML_VERSION >= (4, 13, 0)
+  Toploop.all_directive_names ()
+#else
+  Hashtbl.fold (fun dir _ acc -> dir::acc) Toploop.directive_table []
+#endif
+
+#if OCAML_VERSION >= (4, 10, 0)
+let lookup_type longident env =
+  Env.find_type_by_name longident env
+#else
+let lookup_type longident env =
+  let path = Env.lookup_type longident env in
+  (path, Env.find_type path env)
+#endif
+
+let set_load_path path =
+#if OCAML_VERSION >= (5, 0, 0)
+  Load_path.init path ~auto_include:Load_path.no_auto_include
+#else
+  Load_path.init path
+#endif
+
+let toploop_use_silently fmt name =
+#if OCAML_VERSION >= (4, 14, 0)
+  Toploop.use_silently fmt (File name)
+#else
+  Toploop.use_silently fmt name
+#endif
+
+module Persistent_signature =
+#if OCAML_VERSION >= (4, 09, 0)
+  Persistent_env.Persistent_signature
+#else
+  Env.Persistent_signature
+#endif
+
+let toploop_set_paths () =
+#if OCAML_VERSION >= (5, 0, 0)
+  Toploop.set_paths ~auto_include:Load_path.no_auto_include ()
+#else
+  Toploop.set_paths ()
+#endif
+
+let toploop_load_file ppf fn =
+#if OCAML_VERSION >= (4, 13, 0)
+  Toploop.load_file ppf fn
+#else
+  Topdirs.load_file ppf fn
+#endif
+
+let iter_structure expr =
+#if OCAML_VERSION >= (4,09,0)
+  let next iterator e = Tast_iterator.default_iterator.expr iterator e in
+  let expr iterator = expr (next iterator) in
+  let iter = { Tast_iterator.default_iterator with expr } in
+  iter.structure iter
+#else
+  let module Search =
+    TypedtreeIter.MakeIterator(struct
+      include TypedtreeIter.DefaultIteratorArgument
+
+      let enter_expression = expr ignore
+     end) in
+  Search.iter_structure
+#endif


### PR DESCRIPTION
The utop code base is full of `#if OCAML_VERSION` to adapt to the changes in `compiler-libs`.
This has some issues - for example the corresponding logic is harder to recognize, and some logic is duplicated in several places. Also, this prevents using a formatter.

One medium-term goal is to move most of the compat functions to a new `Utop_compat` module which would be the only place we use `cppo`.

This PR contains the "easy" cases - moving existing functions, etc. It is a bit more difficult (and controversial) to convert pattern matching to this pattern so it'll be done in a separate PR.

While doing that, several cases of duplications were found so this explains the negative diffstat.
