### PR TITLE
Qualify () constructor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,9 @@
 
 * Mark `prompt_continue`, `prompt_comment`, `smart_accept`, `new_prompt_hooks`,
   `at_new_prompt` as deprecated (they have been documented as such since 2012
-  and most of them are ignored) (#xxx @emillon)
+  and most of them are ignored) (#415, @emillon)
+
+* Qualify `()` constructor in generated expressions. (#418, fixes #417, @emillon)
 
 2.11.0 (2023-01-05)
 -------------------

--- a/src/lib/uTop.ml
+++ b/src/lib/uTop.ml
@@ -349,7 +349,7 @@ let check_phrase phrase =
         let env = !Toploop.toplevel_env in
         (* Construct "let _ () = let module _ = struct <items> end in ()" in order to test
            the typing and compilation of [items] without evaluating them. *)
-        let unit = with_loc loc (Longident.Lident "()") in
+        let unit = with_loc loc (Longident.Ldot (Lident "Unit", "()")) in
         let top_def =
           let open Ast_helper in
           with_default_loc loc

--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -574,7 +574,6 @@ type rewrite_rule = {
 let longident_lwt_main_run = Longident.Ldot (Longident.Lident "Lwt_main", "run")
 let longident_async_thread_safe_block_on_async_exn =
   Longident.(Ldot (Ldot (Lident "Async", "Thread_safe"), "block_on_async_exn"))
-let longident_unit = Longident.Lident "()"
 
 let rewrite_rules = [
   (* Rewrite Lwt.t expressions to Lwt_main.run <expr> *)


### PR DESCRIPTION
We are building a hidden expression that contains "()" but it is not
qualified. So it will pick the constructor in scope. This can cause
problems if `()` has been redefined. The correct fix is to qualify it as
part of the `Unit` module.

(additionally, this removes an unused ident)

Fixes #417
