### PR TITLE
fix regression with unit qualification

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 unreleased
 ----------
 
+* Fix regression with unit qualification when a `Unit` module is in scope with
+  no `()` constructor (#429, fixes #428, @emillon)
+
 * emacs: add completion-at-point implementation (#406, fixes #261, @j-shilling)
 
 2.12.0 (2023-04-17)

--- a/src/lib/uTop.ml
+++ b/src/lib/uTop.ml
@@ -349,7 +349,10 @@ let check_phrase phrase =
         let env = !Toploop.toplevel_env in
         (* Construct "let _ () = let module _ = struct <items> end in ()" in order to test
            the typing and compilation of [items] without evaluating them. *)
-        let unit = with_loc loc (Longident.Ldot (Lident "Unit", "()")) in
+        let unit =
+          let (%.) a b = Longident.Ldot (a, b) in
+          with_loc loc (Lident "Stdlib" %. "Unit" %. "()")
+        in
         let top_def =
           let open Ast_helper in
           with_default_loc loc


### PR DESCRIPTION
Fixes #428

The change in #418 introduced a regression if a `Unit` module in scope does not have a `()` constructor in it.

This switches to the more explicit `Stdlib.Unit.()` path.
