### PR TITLE
XDG Base Directory Compliance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 2.13.0 (unreleased)
 -------------------
 
+* Load files from XDG directories (the legacy paths still work). (#431,
+  @Skyb0rg007)
+
 * Remove deprecated values `prompt_continue`, `prompt_comment`, `smart_accept`,
   `new_prompt_hooks`, `at_new_prompt` (#..., @emillon)
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Customization
 ### Colors
 
 To add colors to utop, copy one of the files `utoprc-dark` or
-`utoprc-light` to `~/.utoprc`. `utoprc-dark` is for terminals with
+`utoprc-light` to `~/.config/utop/utoprc`. `utoprc-dark` is for terminals with
 dark colors (such as white on black) and `utoprc-light` is for
 terminals with light colors (such as black on white).
 

--- a/dune-project
+++ b/dune-project
@@ -26,4 +26,5 @@
   (zed (>= 3.2.0))
   (react (>= 1.0.0))
   (cppo (>= 1.1.2))
-  (alcotest :with-test)))
+  (alcotest :with-test)
+  (xdg (>= 3.9.0))))

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -4,7 +4,7 @@
  (wrapped false)
  (modes byte)
  (libraries compiler-libs.toplevel findlib.top lambda-term logs.lwt threads
-   zed)
+   xdg zed)
  (preprocess
   (action
    (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file}))))

--- a/src/lib/uTop.ml
+++ b/src/lib/uTop.ml
@@ -23,9 +23,10 @@ let version = "%%VERSION%%"
 (* +-----------------------------------------------------------------+
    | History                                                         |
    +-----------------------------------------------------------------+ *)
+module Default_paths = UTop_private.Default_paths
 
 let history = LTerm_history.create []
-let history_file_name = ref (Some (Filename.concat LTerm_resources.home ".utop-history"))
+let history_file_name = ref (Some (Default_paths.history_file_name))
 let history_file_max_size = ref None
 let history_file_max_entries = ref None
 let stashable_session_history = UTop_history.create ()

--- a/src/lib/uTop_private.ml
+++ b/src/lib/uTop_private.ml
@@ -9,6 +9,27 @@
 
 open Lwt_react
 
+module Default_paths = struct
+  let ( / ) = Filename.concat
+  let xdg = Xdg.create ~env:Sys.getenv_opt ()
+
+  let resolve ~legacy ~filename =
+    if Sys.file_exists legacy then
+      legacy
+    else
+      filename
+
+  let history_file_name =
+    resolve
+      ~legacy:(LTerm_resources.home / ".utop-history")
+      ~filename:(Xdg.state_dir xdg / "utop-history")
+
+  let config_file_name =
+    resolve
+      ~legacy:(LTerm_resources.home / ".utoprc")
+      ~filename:(Xdg.config_dir xdg / "utoprc")
+end
+
 let size, set_size =
   let ev, set_size = E.create () in
   let init = S.const { LTerm_geom.rows = 25; LTerm_geom.cols = 80 } in
@@ -27,7 +48,7 @@ let ui, set_ui = S.create Console
 
 let error_style = ref LTerm_style.none
 
-(* Config from ~/.utoprc *)
+(* Config from $XDG_CONFIG_HOME/utop/utoprc *)
 let autoload = ref true
 
 let margin_function, set_margin_function =

--- a/src/lib/uTop_styles.ml
+++ b/src/lib/uTop_styles.ml
@@ -12,6 +12,7 @@ open UTop_token
 let return, (>>=) = Lwt.return, Lwt.(>>=)
 
 module String_set = Set.Make (String)
+module Default_paths = UTop_private.Default_paths
 
 type styles = {
   mutable style_keyword : LTerm_style.t;
@@ -56,7 +57,7 @@ let styles = {
 }
 
 let load () =
-  let fn = Filename.concat LTerm_resources.home ".utoprc" in
+  let fn = Default_paths.config_file_name in
   Lwt.catch
     (fun () ->
       LTerm_resources.load fn >>= fun res ->

--- a/utop.opam
+++ b/utop.opam
@@ -23,6 +23,7 @@ depends: [
   "react" {>= "1.0.0"}
   "cppo" {>= "1.1.2"}
   "alcotest" {with-test}
+  "xdg" {>= "3.9.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/utoprc-dark
+++ b/utoprc-dark
@@ -1,6 +1,6 @@
 ! -*- conf-xdefaults -*-
 
-! Copy this file to ~/.utoprc
+! Copy this file to $XDG_CONFIG_HOME/utoprc (~/.config/utoprc)
 
 ! Common resources
 

--- a/utoprc-light
+++ b/utoprc-light
@@ -1,6 +1,6 @@
 ! -*- conf-xdefaults -*-
 
-! Copy this file to ~/.utoprc
+! Copy this file to $XDG_CONFIG_HOME/utoprc (~/.config/utoprc)
 
 ! Common resources
 


### PR DESCRIPTION
This PR adds support for the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) by moving the `~/.utop-history` and `~/.utoprc` files to `$XDG_CACHE_HOME/utop-history` and `$XDG_CONFIG_HOME/utop/utoprc` respectively.
Both of these changes still support fallbacks to their original locations to not introduce a strict backwards incompatibility.

While this history file should really be saved as `$XDG_STATE_HOME/utop-history`, the XDG state directory is currently unsupported in the current version of lambda-term. I have filed a PR to that project [here](https://github.com/ocaml-community/lambda-term/pull/113) to add the functionality for downstream use here.

This PR improves on #362 by utilizing the existing dependency on [lambda-term](https://github.com/ocaml-community/lambda-term), and also updating the location of the `utoprc` file location.