### PR TITLE
Fix behavior of utop -stdin

### DIFF
--- a/src/lib/uTop_compat.ml
+++ b/src/lib/uTop_compat.ml
@@ -89,7 +89,7 @@ let set_load_path path =
 
 let toploop_use_silently fmt name =
 #if OCAML_VERSION >= (4, 14, 0)
-  Toploop.use_silently fmt (File name)
+  Toploop.use_silently fmt (match name with "" -> Stdin | _ -> File name)
 #else
   Toploop.use_silently fmt name
 #endif


### PR DESCRIPTION
See issue #433 for how the problem showed itself.

In 4.14 the behavior of Toploop.use_silently changed. Previously, the empty string would be interpreted as a request for Stdin. Now File and Stdin are different constructors of Toploop.input.

This PR adds logic to the wrapper already used to use the File constructor to select Stdin when the filename passed is the empty string.

NB this means that `utop -stdin` works but `utop ""` has the same effect, which AFAICT was the behavior pre-4.14 but may not be desirable.