### PR TITLE
Fix unavailable expunge on Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 2.13.1 (Pending)
 ----------------
 
-* Fix unavailable expunge on Windows (@jonahbeckford)
+* Fix unavailable expunge on Windows (#447, @jonahbeckford)
 
 2.13.0 (2023-07-03)
 -------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+2.13.1 (Pending)
+----------------
+
+* Fix unavailable expunge on Windows (@jonahbeckford)
+
 2.13.0 (2023-07-03)
 -------------------
 

--- a/src/top/dune
+++ b/src/top/dune
@@ -33,7 +33,7 @@
 (rule
  (targets utop-expunged.bc)
  (action
-  (run %{ocaml_where}/expunge %{dep:utop.bc} %{targets}
+  (run %{ocaml_where}/expunge%{ext_exe} %{dep:utop.bc} %{targets}
     %{read-lines:modules.txt})))
 
 (install


### PR DESCRIPTION
Without this commit, you get:

```
File "src/top/dune", line 33, characters 0-131:
33 | (rule
34 |  (targets utop-expunged.bc)
35 |  (action
36 |   (run %{ocaml_where}/expunge %{dep:utop.bc} %{targets}
37 |     %{read-lines:modules.txt})))
Error: File unavailable:
Z:/source/dkml/build/pkg/bump/.ci/o/PR/lib/ocaml/expunge
```