### PR TITLE
Bring utop(1) man page up to date with README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Integration with Emacs
 
 `utop.el` is a package that provides `utop` integration with Emacs.
 The package allows you to run `utop` inside Emacs and to evaluate
-code in it straight from your source buffers (with the help with `utop-minor-mode`).
+code in it straight from your source buffers (with the help of `utop-minor-mode`).
 
 Those features are covered in more details in the ["Usage"](#usage-emacs) section.
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ To use utop, simply run:
 
     utop
 
-utop display a bar after the prompt which is used to show possible
-completions in real-time. You can navigate in it using `M-left` and
+utop displays a bar after the prompt which is used to show possible
+completions in real time. You can navigate in it using `M-left` and
 `M-right`, and select one completion using `M-down`. The `M` denotes
-the meta key, which is `Alt` most of the time.
+the meta key, which is `Alt` on most systems.
 
 Customization
 -------------
@@ -104,7 +104,7 @@ You can turn on the vi edit mode by `#edit_mode_vi`. It currently supports
 three vi modes: normal, insert, visual mode, and you can get/set content
 with vim-like registers.
 
-This special edit mode is evolving rapidly, see the CHANGES of lambda-term for the rapidly changing information.
+This special edit mode is evolving rapidly; see the CHANGES of lambda-term for the rapidly changing information.
 
 ### UTop API
 
@@ -133,7 +133,9 @@ started from within Emacs.
 The recommended way to install `utop.el` is via Emacs's built-in package manager `package.el`.
 
 `utop.el` is available on the community-maintained
-[MELPA Stable](https://stable.melpa.org) and [MELPA](https://melpa.org) `package.el` repositories. If you're not using them already, please follow the setup instructions [here](https://melpa.org/#/getting-started).
+[MELPA Stable](https://stable.melpa.org) and [MELPA](https://melpa.org) `package.el` repositories.
+If you're not using them already, please follow the setup instructions
+[here](https://melpa.org/#/getting-started).
 
 **Note:** Using MELPA Stable is recommended as it has the latest stable version.
 MELPA has a development snapshot for users who don't mind breakage but
@@ -260,13 +262,13 @@ correctly:
     Fatal error: cannot load shared library dlllwt-unix_stubs
     Reason: dlopen(dlllwt-unix_stubs.so, 138): image not found
 
-It shall point to the directory `stublibs` inside your ocaml installation.
+It should point to the directory `stublibs` inside your ocaml installation.
 
 Automatically installing toplevel printers
 ------------------------------------------
 
 Utop will automatically install toplevel printers for custom
-types if their interface file is marked with an
+types if their interface files are marked with an
 `[@@ocaml.toplevel_printer]` attribute.  Adding this annotation to
 your libraries will remove the need to have a separate `top` package
 to install the printers.
@@ -297,7 +299,7 @@ Creating a custom utop-enabled toplevel
 
 The recommended way to build a custom utop toplevel is via
 [Dune][dune]. The entry point of the custom utop must call
-`UTop_main.main`. For instance write the following `myutop.ml` file:
+`UTop_main.main`. For instance, write the following `myutop.ml` file:
 
 ```ocaml
 let () = UTop_main.main ()
@@ -312,14 +314,14 @@ and the following dune file:
  (libraries utop))
 ```
 
-then to build the toplevel, run:
+then, to build the toplevel, run:
 
 ```
 $ dune myutop.bc
 ```
 
 Note the `-linkall` in the link flags. By default OCaml doesn't link
-unused modules, however for a toplevel you don't know in advance what
+unused modules. However for a toplevel you don't know in advance what
 the user is going to use so you must link everything.
 
 If you want to include more libraries in your custom utop, simply add
@@ -341,7 +343,7 @@ supported.
 
 ### Manually, with ocamlfind
 
-This section describe methods using ocamlfind. These are no longer
+This section describe methods using `ocamlfind`. These are no longer
 tested, so there is no guarantee they still work.
 
 If you want to create a custom toplevel with utop instead of the
@@ -349,7 +351,7 @@ classic one you need to link it with utop and its dependencies and
 call `UTop_main.main` in the last linked unit. You also need to pass
 the `-thread` switch when linking the toplevel.
 
-The easiest way to do that is by using ocamlfind:
+The easiest way to do that is by using `ocamlfind`:
 
     $ ocamlfind ocamlmktop -o myutop -thread -linkpkg -package utop myutop_main.cmo
 
@@ -359,14 +361,14 @@ Where `myutop_main.ml` contains:
 let () = UTop_main.main ()
 ```
 
-You can also use the `ocamlc` sub-command instead of `ocamlmktop`, in
-this case you need to pass these thee extra arguments:
+You can also use the `ocamlc` sub-command instead of `ocamlmktop`. In
+this case you need to pass these three extra arguments:
 
 * `-linkall` to be sure all units are linked into the produced toplevel
 * `-package compiler-libs.toplevel`
 * `-predicates create_toploop`
 
-With the last option ocamlfind will generate a small ocaml unit,
+With the last option `ocamlfind` will generate a small ocaml unit,
 linked just before `myutop_main.cmo`, which will register at startup
 packages already linked in the toplevel so they are not loaded again
 by the `#require` directive. It does the same with the `ocamlmktop`
@@ -377,9 +379,9 @@ For example:
     $ ocamlfind ocamlc -o myutop -thread -linkpkg -linkall -predicates create_toploop \
         -package compiler-libs.toplevel,utop myutop.cmo
 
-Note that if you are not using ocamlfind, you will need to do that
+Note that if you are not using `ocamlfind`, you will need to do that
 yourself. You have to call `Topfind.don't_load` with the list of all
 packages linked with the toplevel.
 
-A full example using ocamlbuild is provided in the
+A full example using `ocamlbuild` is provided in the
 [examples/custom-utop](examples/custom-utop) directory.

--- a/man/utop.1
+++ b/man/utop.1
@@ -1,11 +1,11 @@
 \" utop.1
 \" ------
-\" Copyright : (c) 2011, Jeremie Dimino <jeremie@dimino.org>
+\" Copyright : (c) 2023, Jeremie Dimino <jeremie@dimino.org>
 \" Licence   : BSD3
 \"
 \" This file is a part of utop.
 
-.TH UTOP 1 "August 2011"
+.TH UTOP 1 "September 2023"
 
 .SH NAME
 utop \- Universal toplevel for OCaml
@@ -33,15 +33,15 @@ When you start
 what you see is the prompt followed by a bar containing words. This is
 the completion bar: it contains the possible completion and is updated
 as you type. The highlighted word in the completion bar is the
-selected word. You can navigate using the keys Alt+Left and Alt+Right
-and you can complete using the currently selected word by pressing
-Alt+Tab (you can configure these bindings in the file
+selected word. You can navigate using the keys \fBM-Left\fR and \fBM-Right\fR
+and select one completion using \fBM-down\fR. Here \fBM\fR represents the meta key,
+which is \fBAlt\fR on most systems. You can configure these bindings in the file
 .I ~/.config/lambda-term-inputrc
-, see
+- see
 .BR lambda-term-inputrc (5)
-for details).
+for details.
 
-utop supports completion on:
+\fButop\fR supports completion on:
 
         * directives and directive arguments
         * identifiers
@@ -61,7 +61,7 @@ You can then add this line to your
 .I ~/.config/utop/init.ml
 file.
 
-To turn off utop's advanced prompt features, add the following to init.ml
+To turn off \fButop\fR's advanced prompt features, add the following to \fIinit.ml\fR
 to turn off respectively (a) colors and the upper information line, and
 (b) the lower boxed list of possible completions:
 
@@ -74,18 +74,39 @@ file. See
 .BR utoprc (5)
 for that.
 
-Finally utop can run in emacs. For that you have to add the following line to your
-.I ~/.emacs
-file:
+Vi edit mode is enabled by the command
 
-        (autoload 'utop "utop" "Toplevel for OCaml" t)
+        #edit_mode_vi
 
-then you can run utop by pressing M-x and typing "utop". utop supports
-completion in emacs mode. Just press Tab to complete a word. You can
-also integrate it with the tuareg, caml or typerex mode. For that add
-the following lines to your
-.I ~/.emacs
-file:
+It currently supports three vi modes: normal, insert, visual mode, and you can
+get/set content with vim-like registers.
+
+.I utop.el
+is a package that provides
+.B utop
+integration with Emacs. The package allows you to run
+.B utop
+inside Emacs and to evaluate code in it straight from your source buffers
+(with the help of \fIutop-minor-mode\fR).
+The recommended way to install
+.I utop.el
+is via Emacs's built-in package manager \fBpackage.el\fR.
+More detailed installation and configuration instructions may be found
+on the project's code repository at \fIhttps://github.com/ocaml-community/utop\fR.
+
+You can start \fButop\fR inside Emacs with \fBM-x utop\fR.
+
+The default install also has a minor mode with the following key bindings:
+
+        \fBC-c C-s\fR Start a utop buffer (\fIutop\fR)
+        \fBC-x C-e\fR Evaluate the current phrase (\fIutop-eval-phrase\fR)
+        \fBC-x C-r\fR Evaluate the selected region (\fIutop-eval-region\fR)
+        \fBC-c C-b\fR Evaluate the current buffer (\fIutop-eval-buffer\fR)
+        \fBC-c C-k\fR Kill a running utop process (\fItop-kill\fR)
+        \fBC-c C-z\fR Switch to utop process (\fIutop-switch-to-repl\fR)
+
+You can enable the minor mode uxing \fBM-x utop-minor-mode\fR, or you can
+have it enabled by default with the following configuration:
 
         (autoload 'utop-minor-mode "utop" "Minor mode for utop" t)
         (add-hook 'tuareg-mode-hook 'utop-minor-mode)
@@ -93,7 +114,7 @@ file:
 .SH OPTIONS
 See
 .B utop --help
-for the the list of available options. There is considerable overlap
+for the full list of available options. There is considerable overlap
 with options available for
 .BR ocaml (1).
 

--- a/man/utop.1
+++ b/man/utop.1
@@ -25,13 +25,13 @@ utop \- Universal toplevel for OCaml
 .SH DESCRIPTION
 
 .B utop
-is a enhanced toplevel for OCaml with many features, including context
+is an enhanced toplevel for OCaml with many features, including context
 sensitive completion.
 
 When you start
 .B utop
 what you see is the prompt followed by a bar containing words. This is
-the completion bar, it contains the possible completion and is updated
+the completion bar: it contains the possible completion and is updated
 as you type. The highlighted word in the completion bar is the
 selected word. You can navigate using the keys Alt+Left and Alt+Right
 and you can complete using the currently selected word by pressing
@@ -51,9 +51,9 @@ utop supports completion on:
         * object methods
 
 Colors are by default configured for terminals with dark colors, such
-as white on black, so the prompt may looks too bright on light colors
+as white on black, so the prompt may look too bright on light-colored
 terminals. You can change that by setting the color profile of
-utop. For that type:
+utop. To do that, type:
 
         UTop.set_profile UTop.Light;;
 
@@ -80,7 +80,7 @@ file:
 
         (autoload 'utop "utop" "Toplevel for OCaml" t)
 
-then you can run utop by pressing M-x and typing "utop". utop support
+then you can run utop by pressing M-x and typing "utop". utop supports
 completion in emacs mode. Just press Tab to complete a word. You can
 also integrate it with the tuareg, caml or typerex mode. For that add
 the following lines to your
@@ -112,7 +112,7 @@ Show absolute filenames in error message.
 Add \fIdir\fR to the list of include directories.
 .TP
 .BI -init " file"
-Load \fIfile\fR instead of default init file.
+Load \fIfile\fR instead of the default init file.
 .TP
 .BI -labels
 Use commuting label mode.
@@ -127,10 +127,10 @@ Do not compile assertion checks.
 Ignore non-optional labels in types.
 .TP
 .BI -nostdlib
-Do not add default directory to the list of include directories.
+Do not add the default directory to the list of include directories.
 .TP
 .BI -ppx " command"
-Pipe abstract syntax trees through preprocessor \fIcommand\fR.
+Pipe abstract syntax trees through the preprocessor \fIcommand\fR.
 .TP
 .BI -principal
 Check principality of type inference.

--- a/man/utoprc.5
+++ b/man/utoprc.5
@@ -24,7 +24,7 @@ ignored. Configuration lines are of the form:
         <wildcard>: <value>
 
 .I <wildcard>
-may contains the '*' star character. In that case any key which match
+may contain the '*' asterisk character. In that case any key which matches
 the pattern is given the value after the colon.
 
 The boolean key
@@ -111,7 +111,7 @@ example:
 
         identifier.foreground:  #5fbf7f
 
-utop will choose the nearest color of the terminal when specifying a
+utop will choose the nearest color of the terminal when specifying an
 X11 color or a color given by its RGB components. If you are using
 gnome-terminal or konsole, you can enable 256 colors by setting the
 environment variable TERM to "xterm-256color".


### PR DESCRIPTION
Here I tried to bring the utop(1) man page a bit more up to date with the README since it contained some information like key bindings that no longer seemed correct. I also included information about Vi mode and Emacs integration. The man pages should be pretty tight and not include things like installation instructions – I rather added a reference to the README itself.