### PR TITLE
Fix completion of symbols in modules

### DIFF
--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -600,16 +600,7 @@ it is started."
        (setq utop-completion nil))
       ;; A new possible completion
       ("completion"
-       (catch 'done
-         (dolist (prefix utop-completion-prefixes)
-           ;; We need to handle specially prefixes like "List.m" as
-           ;; the responses from utop don't include the module prefix.
-           (let ((prefix (if (string-match-p "\\." prefix)
-                             (cadr (split-string prefix "\\."))
-                           prefix)))
-             (when (string-prefix-p prefix argument)
-               (push argument utop-completion)
-               (throw 'done t))))))
+       (push argument utop-completion))
       ;; End of completion
       ("completion-stop"
        (utop-set-state 'edit)
@@ -705,6 +696,15 @@ If ADD-TO-HISTORY is t then the input will be added to history."
 ;; | Completion                                                      |
 ;; +-----------------------------------------------------------------+
 
+(defun utop--completion-prefix ()
+  "The completion prefix"
+  ;; This is actually very wrong!
+  ;; I'm assuming the thing we wanna complete is the last thing on
+  ;; the last line in the prompt, which is usually true, but not given.
+  (let* ((last-line (car (last utop-completion-prefixes)))
+         (prefix    (car (last (string-split  last-line "\\.")))))
+    prefix))
+
 (defun utop-complete-input (input)
   "Send input to complete to utop."
   ;; Split it
@@ -744,7 +744,7 @@ If ADD-TO-HISTORY is t then the input will be added to history."
 
   (when (>= (length utop-capf-completion-candidates) 1)
     (list
-     utop-prompt-max
+     (- (point) (length (utop--completion-prefix)))
      (point)
      utop-capf-completion-candidates)))
 


### PR DESCRIPTION
Fixes #455 

The reason you don't get a completion when typing a symbol in a module, is because the range from `utop-prompt-max` to `(point)` does not match the actual prefix of the completion returned from `utop`. The fix is to set the `start` and `end` positions of the completion corresponding to the position of the prefix `utop` is actually completing.

Before, there was a fix that attempted to fix the same thing with some special logic in the processing of the lines returned from `utop`, but using the `cadr` of the split string will not work with more than one level of modules, and even then the range of the completion was not set correctly, leading to the issue. With this fix, we can complete things like `List.<TAB>`, and even `Base.Float.O.<TAB>`.

There might be a better way to determine the completion prefix; I'm not experienced enough with OCaml to know if splitting by `.` covers finding the prefix for everything that `utop` can autocomplete, but at least it is a start.

I'm also not the most experienced elisp hacker, so if the code is in bad style or there is something I have overlooked,  feel free to make suggestions as to how I can improve the fix.