### PR TITLE
Customize starting directory for utop

### DIFF
--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -75,6 +75,18 @@ with Emacs to provide an enhanced environment."
   :type 'string
   :safe 'stringp)
 
+(defcustom utop-starting-directory 'current-directory
+  "Directory in which utop will be started.
+
+Can be the `current-directory' (default) to use the current buffer's directory or
+`project-root' to use the project root as implied by project.el. For most
+users, `current-directory' is completely sufficient.
+However, if using an .ocamlinit file in the root directory,
+it may be desirable to run the project from the root directory."
+
+  :type '(choice (const :tag "Project root" project-root)
+                 (const :tag "Current directory" current-directory)))
+
 (defcustom utop-edit-command t
   "Whether to read the command from the minibuffer before running utop.
 
@@ -1073,9 +1085,16 @@ defaults to 0."
   ;; Set the state to done to allow utop to be restarted if
   ;; start-process fails
   (setq utop-state 'done)
+  (let ((default-directory
+      (cond ((eq utop-starting-directory 'project-root)
+	      (project-root (project-current)))
+	     ((eq utop-starting-directory 'current-directory)
+	      default-directory)
+	     (t
+	      (error "Wrong value for `utop-starting-directory', please check this variable documentation and set it to a proper value")))))
 
-  ;; Create the sub-process
-  (setq utop-process (apply 'start-process "utop" (current-buffer) (car arguments) (cdr arguments)))
+    ;; Create the sub-process
+    (setq utop-process (apply 'start-process "utop" (current-buffer) (car arguments) (cdr arguments))))
 
   ;; Set the initial state: we are waiting for ocaml to send the
   ;; initial prompt

--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -1086,12 +1086,14 @@ defaults to 0."
   ;; start-process fails
   (setq utop-state 'done)
   (let ((default-directory
-      (cond ((eq utop-starting-directory 'project-root)
-	      (project-root (project-current)))
-	     ((eq utop-starting-directory 'current-directory)
-	      default-directory)
-	     (t
-	      (error "Wrong value for `utop-starting-directory', please check this variable documentation and set it to a proper value")))))
+	 (cond ((eq utop-starting-directory 'project-root)
+		(if (project-current)
+		    (project-root (project-current))
+		  (error "`utop-starting-directory' is set to project-root but not currently inside a project")))
+		((eq utop-starting-directory 'current-directory)
+		 default-directory)
+		(t
+		 (error "Wrong value for `utop-starting-directory', please check this variable documentation and set it to a proper value")))))
 
     ;; Create the sub-process
     (setq utop-process (apply 'start-process "utop" (current-buffer) (car arguments) (cdr arguments))))


### PR DESCRIPTION
Hi! I opened up #471 . I use `utop-mode` but wanted to automatically load in my `.ocamlinit` file at the root level of my project without having to pass it in explicitly using the `-init` flag. My solution is to enable a customization to start utop from the project root dir. 

Now when you set the variable `utop-starting-directory` (possibly via customize) to `'project-root`, `project.el` is used to find the current buffer's project root. Then `utop` is called from that directory. If the project cannot be found, an error is thrown. 