### PR TITLE
Use "opam var" instead "opam config var"

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ to your `~/.emacs`:
  'load-path
  (replace-regexp-in-string
   "\n" "/share/emacs/site-lisp"
-  (shell-command-to-string "opam config var prefix")))
+  (shell-command-to-string "opam var prefix")))
 
 ;; Automatically load utop.el
 (autoload 'utop "utop" "Toplevel for OCaml" t)


### PR DESCRIPTION
"opam config var" was deprecared in version 2.1 and generates an error message in the process output:

[WARNING] var was deprecated in version 2.1 of the opam CLI. Use opam var instead or set OPAMCLI environment variable to 2.0.

Prevents evaluating to invalid load-path components:


```elisp
(add-to-list
 'load-path
 (replace-regexp-in-string
  "\n" "/share/emacs/site-lisp"
  (shell-command-to-string "opam config var prefix")))
(car load-path)
```
evaluates to:
```
"[WARNING] var was deprecated in version 2.1 of the opam CLI. Use opam var instead or set OPAMCLI environment variable to 2.0./share/emacs/site-lisp/home/juergen/.opam/default/share/emacs/site-lisp"
```