### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Customization
 ### Colors
 
 To add colors to utop, copy one of the files `utoprc-dark` or
-`utoprc-light` to `~/.config/utop/utoprc`. `utoprc-dark` is for terminals with
+`utoprc-light` to `~/.config/utoprc`. `utoprc-dark` is for terminals with
 dark colors (such as white on black) and `utoprc-light` is for
 terminals with light colors (such as black on white).
 


### PR DESCRIPTION
Hi, I started learning OCaml today and was installing `utop` when I noticed a minor inconsistency in between the directions given in the `utoprc-dark` file and the `README` on the location to store the theme information.

The ones in the `utoprc-dark` worked for me, so creating a PR to update the path in the `README`.