### PR TITLE
Correct paths for utop-history, utoprc: in utop subdirs of XDG base dirs

### DIFF
--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -53,7 +53,10 @@ let init_history () =
         return ()
     | Some fn ->
         Lwt.catch
-          (fun () -> LTerm_history.load UTop.history fn)
+          (fun () ->
+            let dn = Filename.dirname fn in
+            if not (Sys.file_exists dn) then Unix.mkdir dn 0o700;
+            LTerm_history.load UTop.history fn)
           (function
           | Unix.Unix_error (error, func, arg) ->
               Logs_lwt.err (fun m -> m "cannot load history from %S: %s: %s"

--- a/src/lib/uTop_private.ml
+++ b/src/lib/uTop_private.ml
@@ -22,12 +22,12 @@ module Default_paths = struct
   let history_file_name =
     resolve
       ~legacy:(LTerm_resources.home / ".utop-history")
-      ~filename:(Xdg.state_dir xdg / "utop-history")
+      ~filename:(Xdg.state_dir xdg / "utop" / "utop-history")
 
   let config_file_name =
     resolve
       ~legacy:(LTerm_resources.home / ".utoprc")
-      ~filename:(Xdg.config_dir xdg / "utoprc")
+      ~filename:(Xdg.config_dir xdg / "utop" / "utoprc")
 end
 
 let size, set_size =


### PR DESCRIPTION
Issue #481 described failure to load utoprc from its stated location
PR #475 misidentified the issue as an incorrect README

In fact the paths were pointing to files within the XDG base directories themselves rather than in a subdirectory for the utop application.

This patch simply changes $XDG_STATE_HOME/utop-history to $XDG_STATE_HOME/**utop**/utop-history and $XDG_CONFIG_HOME/utoprc to $XDG_CONFIG_HOME/**utop**/utoprc