### PR TITLE
Support camlp5 by using Toploop.parse_toplevel_phrase instead of Parse.toplevel_phrase

### DIFF
--- a/src/lib/uTop.ml
+++ b/src/lib/uTop.ml
@@ -305,7 +305,7 @@ let parse_default parse str eos_is_error =
     | exn ->
         Error ([], "Unknown parsing error (please report it to the utop project): " ^ Printexc.to_string exn)
 
-let parse_toplevel_phrase_default = parse_default Parse.toplevel_phrase
+let parse_toplevel_phrase_default = fun str -> parse_default !Toploop.parse_toplevel_phrase str
 let parse_toplevel_phrase = ref parse_toplevel_phrase_default
 
 let parse_use_file_default = parse_default Parse.use_file


### PR DESCRIPTION
This resolves issue #485 (and the equivalent issue discussed in [this thread](https://discuss.ocaml.org/t/a-possible-workaround-for-supporting-camlp5-on-utop/14502)) by fixing the definition of `parse_toplevel_phrase_default` of `UTop` to use  `!Toploop.parse_toplevel_phrase` instead of `Parse.toplevel_phrase`.

Note that `!Toploop.parse_toplevel_phrase` is equal to `Parse.toplevel_phrase` when utop was just initiated: https://github.com/ocaml/ocaml/blob/trunk/toplevel/topcommon.ml#L29

However, a user may add its preprocessor to `Toploop.parse_toplevel_phrase` later using camlp5, making `!Toploop.parse_toplevel_phrase` and `Parse.toplevel_phrase` unequal.

This patch simply replaces `Parse.toplevel_phrase` with `!Toploop.parse_toplevel_phrase` so that the preprocessor can do its work.
