### PR TITLE
OCaml 5.4 support

### DIFF
--- a/src/lib/uTop_compat.ml
+++ b/src/lib/uTop_compat.ml
@@ -11,9 +11,9 @@ let longident_of_list p = match Longident.unflatten p with
       invalid_arg "UTop_complete.longident_of_list"
   | Some x -> x
 
-let ldot ?(loc=Location.none) p s =
+let ldot ?loc:(_loc=Location.none) p s =
 #if OCAML_VERSION >= (5, 4, 0)
-   Longident.Ldot(Location.mkloc p loc, Location.mkloc s loc)
+  Longident.Ldot(Location.mkloc p _loc, Location.mkloc s _loc)
 #else
   Longident.Ldot(p,s)
 #endif

--- a/src/lib/uTop_compat.ml
+++ b/src/lib/uTop_compat.ml
@@ -26,14 +26,18 @@ let destruct_ldot p s =
 #endif
 
 (* Check whether an identifier is a valid one. *)
-let is_valid_identifier id =
 #if OCAML_VERSION >= (5, 3, 0)
+let is_valid_identifier id =
   Misc.Utf8_lexeme.is_valid_identifier id
+let lax_modname_from_cmi = Unit_info.lax_modname_from_source
 #else
+let is_valid_identifier id =
   id <> "" &&
     (match id.[0] with
        | 'A' .. 'Z' | 'a' .. 'z' |  '_' -> true
        | _ -> false)
+let lax_modname_from_cmi fname =
+  String.capitalize_ascii (Filename.chop_suffix fname ".cmi")
 #endif
 
 let toploop_get_directive name =

--- a/src/lib/uTop_compat.ml
+++ b/src/lib/uTop_compat.ml
@@ -5,6 +5,37 @@ let get_desc x =
   x.Types.desc
 #endif
 
+(* Transform a non-empty list of strings into a long-identifier. *)
+let longident_of_list p = match Longident.unflatten p with
+  | None ->
+      invalid_arg "UTop_complete.longident_of_list"
+  | Some x -> x
+
+let ldot ?(loc=Location.none) p s =
+#if OCAML_VERSION >= (5, 4, 0)
+   Longident.Ldot(Location.mkloc p loc, Location.mkloc s loc)
+#else
+  Longident.Ldot(p,s)
+#endif
+
+let destruct_ldot p s =
+#if OCAML_VERSION >= (5, 4, 0)
+   p.Location.txt, s.Location.txt
+#else
+  p, s
+#endif
+
+(* Check whether an identifier is a valid one. *)
+let is_valid_identifier id =
+#if OCAML_VERSION >= (5, 3, 0)
+  Misc.Utf8_lexeme.is_valid_identifier id
+#else
+  id <> "" &&
+    (match id.[0] with
+       | 'A' .. 'Z' | 'a' .. 'z' |  '_' -> true
+       | _ -> false)
+#endif
+
 let toploop_get_directive name =
 #if OCAML_VERSION >= (4, 13, 0)
   Toploop.get_directive name
@@ -150,4 +181,3 @@ let add_cmi_hook f =
     res
   in
   Persistent_env.Persistent_signature.load := load
-

--- a/src/lib/uTop_complete.ml
+++ b/src/lib/uTop_complete.ml
@@ -23,13 +23,6 @@ let set_of_list = List.fold_left (fun set x -> String_set.add x set) String_set.
    | Utils                                                           |
    +-----------------------------------------------------------------+ *)
 
-(* Check whether an identifier is a valid one. *)
-let is_valid_identifier id =
-  id <> "" &&
-    (match id.[0] with
-       | 'A' .. 'Z' | 'a' .. 'z' |  '_' -> true
-       | _ -> false)
-
 let add id set = if is_valid_identifier id then String_set.add id set else set
 
 let lookup_env f x env =
@@ -376,7 +369,7 @@ let visible_modules () =
             Array.fold_left
               (fun acc fname ->
                 if Filename.check_suffix fname ".cmi" then
-                  String_set.add (String.capitalize_ascii (Filename.chop_suffix fname ".cmi")) acc
+                  String_set.add (lax_modname_from_cmi fname) acc
                 else
                   acc)
               acc

--- a/src/lib/uTop_complete.ml
+++ b/src/lib/uTop_complete.ml
@@ -23,17 +23,6 @@ let set_of_list = List.fold_left (fun set x -> String_set.add x set) String_set.
    | Utils                                                           |
    +-----------------------------------------------------------------+ *)
 
-(* Transform a non-empty list of strings into a long-identifier. *)
-let longident_of_list = function
-  | [] ->
-      invalid_arg "UTop_complete.longident_of_list"
-  | component :: rest ->
-      let rec loop acc = function
-        | [] -> acc
-        | component :: rest -> loop (Longident.Ldot(acc, component)) rest
-      in
-      loop (Longident.Lident component) rest
-
 (* Check whether an identifier is a valid one. *)
 let is_valid_identifier id =
   id <> "" &&
@@ -826,6 +815,7 @@ let complete ~phrase_terminator ~input =
       let prefix = String.sub input (loc.ofs1 + tlen) (String.length input - loc.ofs1 - tlen) in
       begin match Parse.longident (Lexing.from_string prefix) with
       | Longident.Ldot (lident, last_prefix) ->
+        let lident, last_prefix = destruct_ldot lident last_prefix in
         let set = names_of_module lident in
         let compls = lookup last_prefix (String_set.elements set) in
         let start = loc.idx1 + 1 + (String.length prefix - String.length last_prefix) in

--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -1173,18 +1173,17 @@ module Printtyp =
 #endif
 
 #if OCAML_VERSION >= (5,4,0)
-let lbl_res lbl = get_desc lbl.Data_types.lbl_res
-let cstr_res c = get_desc c.Data_types.cstr_res
-let cstr_tag c = c.Data_types.cstr_tag
-let present_arg x = match x with
+  module Data_types = Data_types
+  let present_arg = function
   | Typedtree.Arg x -> Some x
   | Typedtree.Omitted () -> None
 #else
-let lbl_res lbl = get_desc lbl.Types.lbl_res
-let cstr_res c = get_desc c.Types.cstr_res
-let cstr_tag c = c.Types.cstr_tag
-let present_arg x = x
+  module Data_types = Types
+  let present_arg x = x
 #endif
+let lbl_res lbl = get_desc lbl.Data_types.lbl_res
+let cstr_res c = get_desc c.Data_types.cstr_res
+let cstr_tag c = c.Data_types.cstr_tag
 
 let typeof sid =
   let id = Parse.longident (Lexing.from_string sid) in

--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -310,7 +310,7 @@ end = struct
     let comp = Ident.name id in
     match path with
     | None -> Longident.Lident comp
-    | Some path -> Longident.Ldot (path, comp)
+    | Some path -> ldot path comp
 
   let is_auto_printer_attribute (attr : Parsetree.attribute) =
     let name = attr.attr_name in
@@ -529,14 +529,14 @@ type rewrite_rule = {
   (* Whether the rule is enabled or not. *)
 }
 
-let longident_lwt_main_run = Longident.Ldot (Longident.Lident "Lwt_main", "run")
+let longident_lwt_main_run = longident_of_list ["Lwt_main"; "run"]
 let longident_async_thread_safe_block_on_async_exn =
-  Longident.(Ldot (Ldot (Lident "Async", "Thread_safe"), "block_on_async_exn"))
+  longident_of_list ["Async"; "Thread_safe"; "block_on_async_exn"]
 
 let rewrite_rules = [
   (* Rewrite Lwt.t expressions to Lwt_main.run <expr> *)
   {
-    type_to_rewrite = Longident.(Ldot (Lident "Lwt", "t"));
+    type_to_rewrite = longident_of_list ["Lwt"; "t"];
     path_to_rewrite = None;
     required_values = [longident_lwt_main_run];
     rewrite = (fun loc e ->
@@ -551,7 +551,7 @@ let rewrite_rules = [
   (* Rewrite Async.Defered.t expressions to
      Async.Thread_safe.block_on_async_exn (fun () -> <expr>). *)
   {
-    type_to_rewrite = Longident.(Ldot (Ldot (Lident "Async", "Deferred"), "t"));
+    type_to_rewrite = longident_of_list ["Async"; "Deferred"; "t"];
     path_to_rewrite = None;
     required_values = [longident_async_thread_safe_block_on_async_exn];
     rewrite = (fun loc e ->
@@ -1172,6 +1172,20 @@ module Printtyp =
   Printtyp
 #endif
 
+#if OCAML_VERSION >= (5,4,0)
+let lbl_res lbl = get_desc lbl.Data_types.lbl_res
+let cstr_res c = get_desc c.Data_types.cstr_res
+let cstr_tag c = c.Data_types.cstr_tag
+let present_arg x = match x with
+  | Typedtree.Arg x -> Some x
+  | Typedtree.Omitted () -> None
+#else
+let lbl_res lbl = get_desc lbl.Types.lbl_res
+let cstr_res c = get_desc c.Types.cstr_res
+let cstr_tag c = c.Types.cstr_tag
+let present_arg x = x
+#endif
+
 let typeof sid =
   let id = Parse.longident (Lexing.from_string sid) in
   let env = !Toploop.toplevel_env in
@@ -1194,7 +1208,7 @@ let typeof sid =
     with Not_found ->
     try
       let lbl_desc = Env.find_label_by_name id env in
-      let (path, ty_decl) = from_type_desc (get_desc lbl_desc.Types.lbl_res) in
+      let (path, ty_decl) = from_type_desc (lbl_res lbl_desc) in
       let id = Ident.create_local (Path.name path) in
       Some (Printtyp.tree_of_type_declaration id ty_decl Types.Trec_not)
     with Not_found ->
@@ -1210,9 +1224,9 @@ let typeof sid =
     with Not_found ->
     try
       let cstr_desc = Env.find_constructor_by_name id env in
-      match cstr_desc.Types.cstr_tag with
+      match cstr_tag cstr_desc with
       | _ ->
-        let (path, ty_decl) = from_type_desc (get_desc cstr_desc.Types.cstr_res) in
+        let (path, ty_decl) = from_type_desc (cstr_res cstr_desc) in
         let id = Ident.create_local (Path.name path) in
         Some (Printtyp.tree_of_type_declaration id ty_decl Types.Trec_not)
     with Not_found ->
@@ -1522,7 +1536,7 @@ exception Found of Env.t
 
 let get_required_label name args =
   match List.find (fun (lab, _) -> lab = Asttypes.Labelled name) args with
-  | _, x -> x
+  | _, x -> present_arg x
   | exception Not_found -> None
 
 let walk dir ~init ~f =


### PR DESCRIPTION
This PR adds support for OCaml 5.4 by adding new compatibility functions to `uTop_compat`.