### PR TITLE
Adding Clflags.debug before main loop, as in Toploop

### DIFF
--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -1465,6 +1465,7 @@ let main_aux ~initial_env =
     let module Emacs = Emacs (struct end) in
     Printf.printf "Welcome to utop version %s (using OCaml version %s)!\n\n%!" UTop.version Sys.ocaml_version;
     common_init ~initial_env;
+    Clflags.debug := true;
     Emacs.loop ()
   end else begin
     UTop_private.set_ui UTop_private.Console;
@@ -1483,6 +1484,7 @@ let main_aux ~initial_env =
       flush stdout;
       (* Main loop. *)
       try
+        Clflags.debug := true;
         loop term
       with LTerm_read_line.Interrupt ->
         ()

--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -1454,6 +1454,7 @@ let load_inputrc () =
 let protocol_version = 1
 
 let main_aux ~initial_env =
+  Clflags.debug := true;
   Arg.parse args file_argument usage;
 #if OCAML_VERSION >= (5, 0, 0) && OCAML_VERSION < (5, 1, 0)
   Topcommon.load_topdirs_signature ();
@@ -1465,7 +1466,6 @@ let main_aux ~initial_env =
     let module Emacs = Emacs (struct end) in
     Printf.printf "Welcome to utop version %s (using OCaml version %s)!\n\n%!" UTop.version Sys.ocaml_version;
     common_init ~initial_env;
-    Clflags.debug := true;
     Emacs.loop ()
   end else begin
     UTop_private.set_ui UTop_private.Console;
@@ -1484,7 +1484,6 @@ let main_aux ~initial_env =
       flush stdout;
       (* Main loop. *)
       try
-        Clflags.debug := true;
         loop term
       with LTerm_read_line.Interrupt ->
         ()


### PR DESCRIPTION
An [old ocaml commit](https://github.com/ocaml/ocaml/commit/3efba04eb34e914b0a032b90f67ca42e202315f6) moved ``Clflags.debug := true`` from the module initalisation to their ``loop`` function, which we do not call.

So this adds the same just before calling the main (recursive) ``loop`` function in utop, both in normal and emacs mode.
Closes #501.

And then we get good backtraces :
```
─( 09:21:33 )─< command 0 >──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────{ counter: 0 }─
utop # let rec f (h::t) = h + f t;;

Line 1, characters 10-16:
Warning 8 [partial-match]: this pattern-matching is not exhaustive.
Here is an example of a case that is not matched:
[]

val f : int list -> int = <fun>
─( 09:21:33 )─< command 1 >──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────{ counter: 0 }─
utop # let g l = f (5::l);;
val g : int list -> int = <fun>
─( 09:21:42 )─< command 2 >──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────{ counter: 0 }─
utop # g [6;3;8];;
Exception: Match_failure ("//toplevel//", 1, 10).
Raised at f in file "//toplevel//", line 1, characters 10-16
Called from f in file "//toplevel//", line 1, characters 23-26
Called from f in file "//toplevel//", line 1, characters 23-26
Called from f in file "//toplevel//", line 1, characters 23-26
Called from f in file "//toplevel//", line 1, characters 23-26
Called from <unknown> in file "//toplevel//", line 1, characters 0-9
Called from Topeval.load_lambda in file "toplevel/byte/topeval.ml", line 93, characters 4-14
```