### PR TITLE
fix utoprc templates to mention the correct path (changed by #484)

### DIFF
--- a/utoprc-dark
+++ b/utoprc-dark
@@ -1,6 +1,6 @@
 ! -*- conf-xdefaults -*-
 
-! Copy this file to $XDG_CONFIG_HOME/utoprc (~/.config/utoprc)
+! Copy this file to $XDG_CONFIG_HOME/utop/utoprc (~/.config/utop/utoprc)
 
 ! Common resources
 

--- a/utoprc-light
+++ b/utoprc-light
@@ -1,6 +1,6 @@
 ! -*- conf-xdefaults -*-
 
-! Copy this file to $XDG_CONFIG_HOME/utoprc (~/.config/utoprc)
+! Copy this file to $XDG_CONFIG_HOME/utop/utoprc (~/.config/utop/utoprc)
 
 ! Common resources
 


### PR DESCRIPTION
The path for `utoprc` used to be `$XDG_CONFIG_HOME/utoprc`, but #484 has changed it to `$XDG_CONFIG_HOME/utop/utoprc` -- as the former was rightfully deemed incorrect.

However, the `utoprc-dark` and `utoprc-light` templates were not updated in the process ; this PR fixes exactly that.

---

It's worth mentioning that the aforementioned PR introduced a breaking change: people with their `utoprc` in the previous location will not have code highlighting working anymore, and it is not necessarily clear why that is. I think there should be a transition period where a warning is shown if a `utoprc` is found in `.config/` instead of `.config/utop/`.