### PR TITLE
Bring the man pages up to date

### DIFF
--- a/man/utop-full.1
+++ b/man/utop-full.1
@@ -1,17 +1,17 @@
-\" utop.1
-\" ------
+\" utop-full.1
+\" -----------
 \" Copyright : (c) 2011, Jeremie Dimino <jeremie@dimino.org>
 \" Licence   : BSD3
 \"
 \" This file is a part of utop.
 
-.TH UTOP-FULL 1 "August 2011"
+.TH UTOP-FULL 1 "July 12, 2026"
 
 .SH NAME
 utop-full \- Universal toplevel for OCaml
 
 .SH SYNOPSIS
-.B utop
+.B utop-full
 [
 .I options
 ]

--- a/man/utop.1
+++ b/man/utop.1
@@ -5,7 +5,7 @@
 \"
 \" This file is a part of utop.
 
-.TH UTOP 1
+.TH UTOP 1 "July 12, 2026"
 
 .SH NAME
 utop \- Universal toplevel for OCaml
@@ -69,8 +69,10 @@ to turn off respectively (a) colors and the upper information line, and
         UTop.set_show_box false
 
 You can enable basic syntax highlighting in utop by writing a
-.I ~/.utoprc
-file. See
+.I $XDG_CONFIG_HOME/utop/utoprc
+file (usually
+.IR ~/.config/utop/utoprc ).
+See
 .BR utoprc (5)
 for that.
 
@@ -102,12 +104,13 @@ The default install also has a minor mode with the following key bindings:
         \fBC-x C-e\fR Evaluate the current phrase (\fIutop-eval-phrase\fR)
         \fBC-x C-r\fR Evaluate the selected region (\fIutop-eval-region\fR)
         \fBC-c C-b\fR Evaluate the current buffer (\fIutop-eval-buffer\fR)
-        \fBC-c C-k\fR Kill a running utop process (\fItop-kill\fR)
+        \fBC-c C-k\fR Kill a running utop process (\fIutop-kill\fR)
         \fBC-c C-z\fR Switch to utop process (\fIutop-switch-to-repl\fR)
 
 then you can run \fButop\fR by pressing \fBM-x\fR and typing "utop". \fButop\fR supports
 completion in Emacs mode. Just press \fBTab\fR to complete a word. You can
-also integrate it with the tuareg, caml or typerex mode. For that add
+also integrate it with the tuareg, caml, reason or typerex mode. Other
+modes can register support via \fIutop-mode-compat-alist\fR. For that add
 the following lines to your
 .I ~/.emacs
 file:
@@ -125,7 +128,7 @@ with options available for
 A commonly used option is
 \fB-require\fI package\fR
 to load \fIpackage\fR into the execution environment. It is equivalent
-to using \fb#require\fR from inside
+to using \fB#require\fR from inside
 .BR utop (1).
 
 .PP
@@ -161,7 +164,7 @@ Pipe abstract syntax trees through the preprocessor \fIcommand\fR.
 Check principality of type inference.
 .TP
 .BI -safe-string
-Make strings immutable.
+Make strings immutable (only available with OCaml < 5.0).
 .TP
 .BI -short-paths
 Shorten paths in types (the default).
@@ -233,18 +236,33 @@ Display this list of options.
 Display this list of options.
 
 .SH FILES
-.I ~/.config/utop/init.ml
+.I $XDG_CONFIG_HOME/utop/init.ml
 .RS
-The initialization file of the toplevel.
-.RE
+The initialization file of the toplevel (usually
+.IR ~/.config/utop/init.ml ).
+A
+.I .ocamlinit
+file in the current directory or a
 .I ~/.ocamlinit
-.RS
-The alternative initialization file of the toplevel.
+file is also picked up.
 .RE
-.I ~/.utoprc
+.I $XDG_CONFIG_HOME/utop/utoprc
 .RS
-The configuration file for utop. See
+The configuration file for utop (usually
+.IR ~/.config/utop/utoprc ).
+See
 .BR utoprc (5).
+The legacy location
+.I ~/.utoprc
+is still honored if that file exists.
+.RE
+.I $XDG_STATE_HOME/utop/utop-history
+.RS
+The history file (usually
+.IR ~/.local/state/utop/utop-history ).
+The legacy location
+.I ~/.utop-history
+is still honored if that file exists.
 .RE
 .I ~/.config/lambda-term-inputrc
 .RS

--- a/man/utoprc.5
+++ b/man/utoprc.5
@@ -5,19 +5,25 @@
 \"
 \" This file is a part of utop.
 
-.TH UTOPRC 5 "August 2011"
+.TH UTOPRC 5 "July 12, 2026"
 
 .SH NAME
 utoprc \- Configuration file of utop
 
 .SH SYNOPSIS
-.B ~/.utoprc
+.B $XDG_CONFIG_HOME/utop/utoprc
 
 .SH DESCRIPTION
 
 This manual page describes the format of the
+.I $XDG_CONFIG_HOME/utop/utoprc
+file (usually
+.IR ~/.config/utop/utoprc ).
+The legacy location
 .I ~/.utoprc
-file. This is a text file which contains the configuration of
+is still honored if that file exists.
+
+This is a text file which contains the configuration of
 utop. Comments start with a '!' and empty lines are
 ignored. Configuration lines are of the form:
 
@@ -117,13 +123,29 @@ gnome-terminal or konsole, you can enable 256 colors by setting the
 environment variable TERM to "xterm-256color".
 
 .SH FILES
+.I $XDG_CONFIG_HOME/utop/utoprc
+.RS
+.RE
 .I ~/.utoprc
+(legacy)
 
 .SH EXAMPLE
+
+utop ships with two ready-to-use configurations:
+.I utoprc-dark
+for terminals with dark background colors and
+.I utoprc-light
+for terminals with light background colors. Copy one of them to
+.I $XDG_CONFIG_HOME/utop/utoprc
+to use it.
+
 profile:                  dark
 .RS
 .RE
 identifier.foreground:    none
+.RS
+.RE
+module.foreground:        x-palegreen
 .RS
 .RE
 comment.foreground:       x-chocolate1
@@ -150,7 +172,10 @@ char.foreground:          x-light-salmon
 quotation.foreground:     x-purple
 .RS
 .RE
-error.foreground:         x-red
+error.foreground:         red
+.RS
+.RE
+directive.foreground:     x-lightsteelblue
 .RS
 .RE
 parenthesis.background:   blue


### PR DESCRIPTION
I came across the man pages randomly while looking for the syntax highlighting config and figured the stale bits were worth fixing.

They still documented the pre-XDG paths (`~/.utoprc`), even though the config moved to `$XDG_CONFIG_HOME/utop/utoprc` in #484. I've updated utop(1) and utoprc(5) to document the current locations (noting the legacy fallbacks still work), added the previously undocumented history file to FILES, and pointed to the shipped utoprc-dark/utoprc-light configs.

Along the way I also fixed a few small errors: utop-full(1) claimed the binary is called `utop`, `-safe-string` no longer exists on OCaml >= 5.0, the Emacs section was missing reason-mode and `utop-mode-compat-alist`, plus a couple of typos.