### PR TITLE
Declare utop as a test package dependency

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,5 @@
 (test
  (name test_lib)
  (modes byte)
+ (deps (package utop))
  (libraries alcotest utop))


### PR DESCRIPTION
Declares the `utop` package as a dependency of `test_lib`, fixing `Fl_package_base.No_such_package("utop", "")` with Dune after ocaml/dune#14373.